### PR TITLE
Add Prometheus integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Telegraf currently has support for collecting metrics from:
 * System (memory, CPU, network, etc.)
 * Docker
 * MySQL
+* Prometheus (client libraries and exporters)
 * PostgreSQL
 * Redis
 

--- a/config.go
+++ b/config.go
@@ -36,8 +36,13 @@ type Config struct {
 	UserAgent string
 	Tags      map[string]string
 
-	agent   *ast.Table
-	plugins map[string]*ast.Table
+	agent               *ast.Table
+	plugins             map[string]*ast.Table
+	prometheusCollector *ast.Table
+}
+
+type PrometheusCollector struct {
+	ListenAddress string
 }
 
 func (c *Config) Plugins() map[string]*ast.Table {
@@ -80,6 +85,14 @@ func (cp *ConfiguredPlugin) ShouldPass(measurement string) bool {
 func (c *Config) ApplyAgent(v interface{}) error {
 	if c.agent != nil {
 		return toml.UnmarshalTable(c.agent, v)
+	}
+
+	return nil
+}
+
+func (c *Config) ApplyPrometheusCollector(v interface{}) error {
+	if c.prometheusCollector != nil {
+		return toml.UnmarshalTable(c.prometheusCollector, v)
 	}
 
 	return nil
@@ -183,6 +196,8 @@ func LoadConfig(path string) (*Config, error) {
 			}
 		case "agent":
 			c.agent = subtbl
+		case "prometheus_collector":
+			c.prometheusCollector = subtbl
 		default:
 			c.plugins[name] = subtbl
 		}
@@ -260,6 +275,10 @@ database = "telegraf" # required.
 # interval = "10s"
 # debug = false
 # hostname = "prod3241"
+
+[prometheus_collector]
+# If set, expose all metrics on this address for Prometheus
+# listen_address = ":9115"
 
 # PLUGINS
 

--- a/plugins/all/all.go
+++ b/plugins/all/all.go
@@ -3,6 +3,7 @@ package all
 import (
 	_ "github.com/influxdb/telegraf/plugins/mysql"
 	_ "github.com/influxdb/telegraf/plugins/postgresql"
+	_ "github.com/influxdb/telegraf/plugins/prometheus"
 	_ "github.com/influxdb/telegraf/plugins/redis"
 	_ "github.com/influxdb/telegraf/plugins/system"
 )

--- a/plugins/mysql/mysql_test.go
+++ b/plugins/mysql/mysql_test.go
@@ -39,7 +39,7 @@ func TestMysqlGeneratesMetrics(t *testing.T) {
 		var count int
 
 		for _, p := range acc.Points {
-			if strings.HasPrefix(p.Name, prefix.prefix) {
+			if strings.HasPrefix(p.Measurement, prefix.prefix) {
 				count++
 			}
 		}

--- a/plugins/postgresql/postgresql_test.go
+++ b/plugins/postgresql/postgresql_test.go
@@ -91,7 +91,7 @@ func TestPostgresqlDefaultsToAllDatabases(t *testing.T) {
 	var found bool
 
 	for _, pnt := range acc.Points {
-		if pnt.Name == "xact_commit" {
+		if pnt.Measurement == "xact_commit" {
 			if pnt.Tags["db"] == "postgres" {
 				found = true
 				break

--- a/plugins/prometheus/prometheus.go
+++ b/plugins/prometheus/prometheus.go
@@ -1,0 +1,105 @@
+package prometheus
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/influxdb/telegraf/plugins"
+	"github.com/prometheus/client_golang/extraction"
+	"github.com/prometheus/client_golang/model"
+)
+
+type Prometheus struct {
+	Urls []string
+}
+
+var sampleConfig = `
+# An array of urls to scrape metrics from.
+urls = ["http://localhost:9100/metrics"]`
+
+func (r *Prometheus) SampleConfig() string {
+	return sampleConfig
+}
+
+func (r *Prometheus) Description() string {
+	return "Read metrics from one or many prometheus clients"
+}
+
+var ErrProtocolError = errors.New("prometheus protocol error")
+
+// Reads stats from all configured servers accumulates stats.
+// Returns one of the errors encountered while gather stats (if any).
+func (g *Prometheus) Gather(acc plugins.Accumulator) error {
+	var wg sync.WaitGroup
+
+	var outerr error
+
+	for _, serv := range g.Urls {
+		wg.Add(1)
+		go func(serv string) {
+			defer wg.Done()
+			outerr = g.gatherURL(serv, acc)
+		}(serv)
+	}
+
+	wg.Wait()
+
+	return outerr
+}
+
+func (g *Prometheus) gatherURL(url string, acc plugins.Accumulator) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("error making HTTP request to %s: %s", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned HTTP status %s", url, resp.Status)
+	}
+	processor, err := extraction.ProcessorForRequestHeader(resp.Header)
+	if err != nil {
+		return fmt.Errorf("error getting extractor for %s: %s", url, err)
+	}
+
+	ingestor := &Ingester{
+		acc: acc,
+	}
+
+	options := &extraction.ProcessOptions{
+		Timestamp: model.TimestampFromTime(time.Now()),
+	}
+
+	err = processor.ProcessSingle(resp.Body, ingestor, options)
+	if err != nil {
+		return fmt.Errorf("error getting processing samples for %s: %s", url, err)
+	}
+	return nil
+}
+
+type Ingester struct {
+	acc plugins.Accumulator
+}
+
+// Ingest implements an extraction.Ingester.
+func (i *Ingester) Ingest(samples model.Samples) error {
+	for _, sample := range samples {
+		tags := map[string]string{}
+		for key, value := range sample.Metric {
+			if key == model.MetricNameLabel {
+				continue
+			}
+			tags[string(key)] = string(value)
+		}
+		i.acc.Add(string(sample.Metric[model.MetricNameLabel]), float64(sample.Value), tags)
+	}
+	return nil
+}
+
+func init() {
+	plugins.Add("prometheus", func() plugins.Plugin {
+		return &Prometheus{}
+	})
+}

--- a/plugins/prometheus/prometheus_test.go
+++ b/plugins/prometheus/prometheus_test.go
@@ -1,0 +1,56 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/influxdb/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+
+const sampleTextFormat = `# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.00010425500000000001
+go_gc_duration_seconds{quantile="0.25"} 0.000139108
+go_gc_duration_seconds{quantile="0.5"} 0.00015749400000000002
+go_gc_duration_seconds{quantile="0.75"} 0.000331463
+go_gc_duration_seconds{quantile="1"} 0.000667154
+go_gc_duration_seconds_sum 0.0018183950000000002
+go_gc_duration_seconds_count 7
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 15
+`
+
+func TestPrometheusGeneratesMetrics(t *testing.T) {
+        ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            fmt.Fprintln(w, sampleTextFormat)
+          }))
+	defer ts.Close()
+
+	p := &Prometheus{
+		Urls: []string{ts.URL},
+	}
+
+	var acc testutil.Accumulator
+
+	err := p.Gather(&acc)
+	require.NoError(t, err)
+
+	expected := []struct {
+		name  string
+		value float64
+		tags map[string]string
+	}{
+		{"go_gc_duration_seconds_count", 7, map[string]string{}},
+		{"go_goroutines", 15, map[string]string{}},
+	}
+
+	for _, e := range expected {
+		assert.NoError(t, acc.ValidateValue(e.name, e.value))
+	}
+}

--- a/plugins/system/system_test.go
+++ b/plugins/system/system_test.go
@@ -272,7 +272,9 @@ func TestSystemStats_GenerateStats(t *testing.T) {
 	require.NoError(t, err)
 
 	dockertags := map[string]string{
-		"id": "blah",
+		"name": "blah",
+		"id": "",
+		"command": "",
 	}
 
 	assert.True(t, acc.CheckTaggedValue("user", 3.1, dockertags))


### PR DESCRIPTION
Overall this change allows Telegraf to pull metrics from any part of the Prometheus ecosystem, and vice versa.

Firstly, this change makes the mysql and postgres tests compile (I don't know if they pass, as I'm not running either). I also improved the testutil tag comparison, and the systems tests that were incorrectly passing due to that.

Second it adds a Prometheus plugin. This allows Telegraf to pull data from any Prometheus exporter or client library (http://prometheus.io/docs/instrumenting/exporters/ and http://prometheus.io/docs/instrumenting/clientlibs/). This is passed a list of Prometheus scrape URLs.

Finally it adds a Prometheus collector/exporter so that if the user explicitly asks for it, they can get data from Telegraf via HTTP in Prometheus format.