### PR TITLE
convert Redis to use URI, support Redis AUTH

### DIFF
--- a/plugins/redis/redis_test.go
+++ b/plugins/redis/redis_test.go
@@ -40,7 +40,7 @@ func TestRedisGeneratesMetrics(t *testing.T) {
 		}
 	}()
 
-	addr := l.Addr().String()
+	addr := fmt.Sprintf("redis://%s", l.Addr().String())
 
 	r := &Redis{
 		Servers: []string{addr},
@@ -131,7 +131,7 @@ func TestRedisCanPullStatsFromMultipleServers(t *testing.T) {
 		}
 	}()
 
-	addr := l.Addr().String()
+	addr := fmt.Sprintf("redis://%s", l.Addr().String())
 
 	r := &Redis{
 		Servers: []string{addr},


### PR DESCRIPTION
These changes allow for someone to collect stats from Redis that has AUTH configured. In order to accomplish this, I changed the logic to accept a URI (i.e. `redis://x:password@localhost`).