### PR TITLE
skip disk tags with no value

### DIFF
--- a/plugins/system/disk.go
+++ b/plugins/system/disk.go
@@ -55,9 +55,12 @@ func (s *DiskIOStats) Gather(acc plugins.Accumulator) error {
 	}
 
 	for _, io := range diskio {
-		tags := map[string]string{
-			"name":   io.Name,
-			"serial": io.SerialNumber,
+		tags := map[string]string{}
+		if len(io.Name) != 0 {
+			tags["name"] = io.Name
+		}
+		if len(io.SerialNumber) != 0 {
+			tags["serial"] = io.SerialNumber
 		}
 
 		acc.Add("reads", io.ReadCount, tags)


### PR DESCRIPTION
This is a fix for the following error seen in telegraf.log and a corresponding 400 response from influxdb:
2015/07/03 07:00:38 Error in plugins: unable to parse 'io_reads,host=test_host,name=md0,serial= value=1072': missing tag value

Influxdb 0.9.1 now rejects writes with empty tag values. This patch skips tags with no values. A disk serial number does not exist for many devices including md raid arrays and VMs. Other plugins may also want to check for empty tags.

This is my very first golang patch. Please feel free to fix if this is not the best way to do this.