### PR TITLE
Add rethinkdb plugin to all.go

### DIFF
--- a/plugins/all/all.go
+++ b/plugins/all/all.go
@@ -7,5 +7,6 @@ import (
 	_ "github.com/influxdb/telegraf/plugins/postgresql"
 	_ "github.com/influxdb/telegraf/plugins/prometheus"
 	_ "github.com/influxdb/telegraf/plugins/redis"
+	_ "github.com/influxdb/telegraf/plugins/rethinkdb"
 	_ "github.com/influxdb/telegraf/plugins/system"
 )


### PR DESCRIPTION
According to the guidelines:

> To be available within Telegraf itself, plugins must add themselves to the github.com/influxdb/telegraf/plugins/all/all.go file.