### PR TITLE
New option to filter the plugins to run at startup

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"strings"
 
 	"github.com/influxdb/influxdb/client"
 	"github.com/influxdb/telegraf/plugins"
@@ -81,24 +82,49 @@ func (agent *Agent) Connect() error {
 	return nil
 }
 
-func (a *Agent) LoadPlugins() ([]string, error) {
+func (a *Agent) LoadPlugins(pluginsFilter string) ([]string, error) {
 	var names []string
+	var filters []string
+
+	pluginsFilter = strings.TrimSpace(pluginsFilter)
+	if pluginsFilter != "" {
+		filters = strings.Split(":"+pluginsFilter+":", ":")
+	}
 
 	for _, name := range a.Config.PluginsDeclared() {
+
 		creator, ok := plugins.Plugins[name]
+
 		if !ok {
 			return nil, fmt.Errorf("Undefined but requested plugin: %s", name)
 		}
 
-		plugin := creator()
-
-		config, err := a.Config.ApplyPlugin(name, plugin)
-		if err != nil {
-			return nil, err
+		// to know if plugin is enabled or not through filter flag
+		isPluginEnabled := false
+		if len(filters)>0 {
+			for _, runeValue := range filters {
+				if runeValue != "" && strings.ToLower(runeValue) == strings.ToLower(name) {
+					fmt.Printf("plugin [%s] is enabled because present is filter options\n", name)
+					isPluginEnabled = true
+					break
+				}
+			}
+		} else {
+			// if no filter, we ALWAYS accept the plugin
+			isPluginEnabled = true
 		}
 
-		a.plugins = append(a.plugins, &runningPlugin{name, plugin, config})
-		names = append(names, name)
+		if isPluginEnabled {
+			plugin := creator()
+			config, err := a.Config.ApplyPlugin(name, plugin)
+			if err != nil {
+				return nil, err
+			}
+
+			a.plugins = append(a.plugins, &runningPlugin{name, plugin, config})
+			names = append(names, name)
+		}
+
 	}
 
 	sort.Strings(names)

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,5 +1,47 @@
 package telegraf
 
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+
+	// needing to load the plugins
+	_ "github.com/influxdb/telegraf/plugins/all"
+)
+
+func TestAgent_LoadPlugin(t *testing.T) {
+
+	// load a dedicated configuration file
+	config, _ := LoadConfig("./testdata/telegraf-agent.toml")
+	a, _ := NewAgent(config)
+
+	pluginsEnabled, _ := a.LoadPlugins("mysql")
+	assert.Equal(t, 1, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins("foo")
+	assert.Equal(t, 0, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins("mysql:foo")
+	assert.Equal(t, 1, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins("mysql:redis")
+	assert.Equal(t, 2, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins(":mysql:foo:redis:bar")
+	assert.Equal(t, 2, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins("")
+	assert.Equal(t, 14, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins(" ")
+	assert.Equal(t, 14, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins("		")
+	assert.Equal(t, 14, len(pluginsEnabled))
+
+	pluginsEnabled, _ = a.LoadPlugins("\n\t")
+	assert.Equal(t, 14, len(pluginsEnabled))
+}
+
 /*
 func TestAgent_DrivesMetrics(t *testing.T) {
 	var (

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -18,7 +18,7 @@ var fConfig = flag.String("config", "", "configuration file to load")
 var fVersion = flag.Bool("version", false, "display the version")
 var fSampleConfig = flag.Bool("sample-config", false, "print out full sample configuration")
 var fPidfile = flag.String("pidfile", "", "file to write our pid to")
-var fPLuginsFilter = flag.String("filter", "", "filter the plugin to enable")
+var fPLuginsFilter = flag.String("filter", "", "filter the plugins to enable, separator is :")
 
 var Version = "unreleased"
 var Commit = ""

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -18,6 +18,7 @@ var fConfig = flag.String("config", "", "configuration file to load")
 var fVersion = flag.Bool("version", false, "display the version")
 var fSampleConfig = flag.Bool("sample-config", false, "print out full sample configuration")
 var fPidfile = flag.String("pidfile", "", "file to write our pid to")
+var fPLuginsFilter = flag.String("filter", "", "filter the plugin to enable")
 
 var Version = "unreleased"
 var Commit = ""
@@ -58,7 +59,7 @@ func main() {
 		ag.Debug = true
 	}
 
-	plugins, err := ag.LoadPlugins()
+	plugins, err := ag.LoadPlugins(*fPLuginsFilter)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Hello,

I just add a new option to filter plugins to enable at startup.

In the future, we will have a lot of plugins into all.go and into config.toml.
A solution would be to have many differents config files.
Another one could be to use this option to filter the plugins.

```
go run cmd/telegraf/telegraf.go --config telegraf.toml -filter mysql:redis
```

I hope it is a good idea. For me it is nice to understand the code behind and now how to write plugin.
Best regards,

Nicolas
