### PR TITLE
Add connection timeout configuration for InfluxDB.

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -70,7 +70,7 @@ func (agent *Agent) Connect() error {
 		Username:  config.Username,
 		Password:  config.Password,
 		UserAgent: config.UserAgent,
-		Timeout:   config.Timeout * time.Second,
+		Timeout:   config.Timeout.Duration,
 	})
 
 	if err != nil {

--- a/agent.go
+++ b/agent.go
@@ -70,6 +70,7 @@ func (agent *Agent) Connect() error {
 		Username:  config.Username,
 		Password:  config.Password,
 		UserAgent: config.UserAgent,
+		Timeout:   config.Timeout * time.Second,
 	})
 
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Password  string
 	Database  string
 	UserAgent string
+	Timeout   time.Duration
 	Tags      map[string]string
 
 	agent   *ast.Table
@@ -242,6 +243,10 @@ url = "http://localhost:8086" # required.
 
 # The target database for metrics. This database must already exist
 database = "telegraf" # required.
+
+# Timeout in seconds (for the connection with InfluxDB).
+# If not provided, will default to 0 (no timeout)
+# timeout = 5
 
 # username = "telegraf"
 # password = "metricsmetricsmetricsmetrics"

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	Password  string
 	Database  string
 	UserAgent string
-	Timeout   time.Duration
+	Timeout   Duration
 	Tags      map[string]string
 
 	agent   *ast.Table
@@ -244,9 +244,10 @@ url = "http://localhost:8086" # required.
 # The target database for metrics. This database must already exist
 database = "telegraf" # required.
 
-# Timeout in seconds (for the connection with InfluxDB).
+# Connection timeout (for the connection with InfluxDB), formatted as a string.
+# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 # If not provided, will default to 0 (no timeout)
-# timeout = 5
+# timeout = "5s"
 
 # username = "telegraf"
 # password = "metricsmetricsmetricsmetrics"


### PR DESCRIPTION
I've been doing some testing with Telegraf and noticed that when there is a connection / network problem (towards InfluxDB), Telegraf would hang 15 minutes before the connection actually times out (without collecting metrics!).

This adds a ``timeout`` parameter to the config that will be passed to to the InfluxDB client:
http://godoc.org/github.com/influxdb/influxdb/client#Config

Side note: how is this handles when plugins are taking a long time to collect stats / or are there any plans to avoid that a long running plugin will block the collection of stats?