### PR TITLE
Fix redis : change ending call with "\r\n"

### DIFF
--- a/plugins/redis/redis.go
+++ b/plugins/redis/redis.go
@@ -126,7 +126,7 @@ func (g *Redis) gatherServer(addr *url.URL, acc plugins.Accumulator) error {
 		if addr.User != nil {
 			pwd, set := addr.User.Password()
 			if set && pwd != "" {
-				c.Write([]byte(fmt.Sprintf("AUTH %s\n", pwd)))
+				c.Write([]byte(fmt.Sprintf("AUTH %s\r\n", pwd)))
 
 				r := bufio.NewReader(c)
 
@@ -143,7 +143,7 @@ func (g *Redis) gatherServer(addr *url.URL, acc plugins.Accumulator) error {
 		g.c = c
 	}
 
-	g.c.Write([]byte("info\n"))
+	g.c.Write([]byte("info\r\n"))
 
 	r := bufio.NewReader(g.c)
 

--- a/plugins/redis/redis_test.go
+++ b/plugins/redis/redis_test.go
@@ -31,7 +31,7 @@ func TestRedisGeneratesMetrics(t *testing.T) {
 				return
 			}
 
-			if line != "info\n" {
+			if line != "info\r\n" {
 				return
 			}
 
@@ -122,7 +122,7 @@ func TestRedisCanPullStatsFromMultipleServers(t *testing.T) {
 				return
 			}
 
-			if line != "info\n" {
+			if line != "info\r\n" {
 				return
 			}
 


### PR DESCRIPTION
Fix #62 