### PR TITLE
Add ability for disk usage to filter by filesystem type

### DIFF
--- a/plugins/system/disk.go
+++ b/plugins/system/disk.go
@@ -8,16 +8,25 @@ import (
 
 type DiskStats struct {
 	ps PS
+    Fstypes []string
 }
 
 func (_ *DiskStats) Description() string {
 	return "Read metrics about disk usage by mount point"
 }
 
-func (_ *DiskStats) SampleConfig() string { return "" }
+var diskSampleConfig = `
+# By default, telegraf gathers stats from any mounted partition, including
+# NFS shares, /proc, tmpfs.
+# fstypes = ["xfs", "ext4", ...]
+`
+
+func (_ *DiskStats) SampleConfig() string {
+    return diskSampleConfig
+}
 
 func (s *DiskStats) Gather(acc plugins.Accumulator) error {
-	disks, err := s.ps.DiskUsage()
+	disks, err := s.ps.DiskUsage(s.Fstypes)
 	if err != nil {
 		return fmt.Errorf("error getting disk usage info: %s", err)
 	}

--- a/plugins/system/ps.go
+++ b/plugins/system/ps.go
@@ -26,7 +26,7 @@ type DockerContainerStat struct {
 type PS interface {
 	LoadAvg() (*load.LoadAvgStat, error)
 	CPUTimes() ([]cpu.CPUTimesStat, error)
-	DiskUsage() ([]*disk.DiskUsageStat, error)
+	DiskUsage(fstypes []string) ([]*disk.DiskUsageStat, error)
 	NetIO() ([]net.NetIOCountersStat, error)
 	DiskIO() (map[string]disk.DiskIOCountersStat, error)
 	VMStat() (*mem.VirtualMemoryStat, error)
@@ -53,8 +53,8 @@ func (s *systemPS) CPUTimes() ([]cpu.CPUTimesStat, error) {
 	return cpu.CPUTimes(true)
 }
 
-func (s *systemPS) DiskUsage() ([]*disk.DiskUsageStat, error) {
-	parts, err := disk.DiskPartitions(true)
+func (s *systemPS) DiskUsage(fstypes []string) ([]*disk.DiskUsageStat, error) {
+	parts, err := disk.DiskPartitions(fstypes)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/system/ps/disk/disk_darwin.go
+++ b/plugins/system/ps/disk/disk_darwin.go
@@ -9,8 +9,13 @@ import (
 	"github.com/influxdb/telegraf/plugins/system/ps/common"
 )
 
-func DiskPartitions(all bool) ([]DiskPartitionStat, error) {
+func DiskPartitions(fstypes []string) ([]DiskPartitionStat, error) {
 	var ret []DiskPartitionStat
+
+	set := make(map[string]struct{}, len(fstypes))
+	for _, s := range fstypes {
+		set[s] = struct{}{}
+	}
 
 	count, err := Getfsstat(nil, MntWait)
 	if err != nil {
@@ -74,7 +79,10 @@ func DiskPartitions(all bool) ([]DiskPartitionStat, error) {
 			Fstype:     common.IntToString(stat.Fstypename[:]),
 			Opts:       opts,
 		}
-		ret = append(ret, d)
+		_, ok := set[d.Fstype]
+		if ok || len(fstypes) == 0 {
+			ret = append(ret, d)
+		}
 	}
 
 	return ret, nil

--- a/plugins/system/ps/disk/disk_freebsd.go
+++ b/plugins/system/ps/disk/disk_freebsd.go
@@ -18,8 +18,13 @@ const (
 	KernDevstatAll = 772
 )
 
-func DiskPartitions(all bool) ([]DiskPartitionStat, error) {
+func DiskPartitions(fstypes []string) ([]DiskPartitionStat, error) {
 	var ret []DiskPartitionStat
+
+	set := make(map[string]struct{}, len(fstypes))
+	for _, s := range fstypes {
+		set[s] = struct{}{}
+	}
 
 	// get length
 	count, err := syscall.Getfsstat(nil, MNT_WAIT)
@@ -87,7 +92,12 @@ func DiskPartitions(all bool) ([]DiskPartitionStat, error) {
 			Fstype:     common.IntToString(stat.Fstypename[:]),
 			Opts:       opts,
 		}
-		ret = append(ret, d)
+
+		_, ok := set[d.Fstype]
+		if ok || len(fstypes) == 0 {
+			ret = append(ret, d)
+		}
+
 	}
 
 	return ret, nil

--- a/plugins/system/ps/disk/disk_linux.go
+++ b/plugins/system/ps/disk/disk_linux.go
@@ -17,7 +17,7 @@ const (
 
 // Get disk partitions.
 // should use setmntent(3) but this implement use /etc/mtab file
-func DiskPartitions(all bool) ([]DiskPartitionStat, error) {
+func DiskPartitions(fstypes []string) ([]DiskPartitionStat, error) {
 
 	filename := "/etc/mtab"
 	lines, err := common.ReadLines(filename)
@@ -25,17 +25,25 @@ func DiskPartitions(all bool) ([]DiskPartitionStat, error) {
 		return nil, err
 	}
 
+	set := make(map[string]struct{}, len(fstypes))
+	for _, s := range fstypes {
+		set[s] = struct{}{}
+	}
+
 	ret := make([]DiskPartitionStat, 0, len(lines))
 
 	for _, line := range lines {
 		fields := strings.Fields(line)
-		d := DiskPartitionStat{
-			Device:     fields[0],
-			Mountpoint: fields[1],
-			Fstype:     fields[2],
-			Opts:       fields[3],
+		_, ok := set[fields[2]]
+		if ok || len(fstypes) == 0 {
+			d := DiskPartitionStat{
+				Device:     fields[0],
+				Mountpoint: fields[1],
+				Fstype:     fields[2],
+				Opts:       fields[3],
+			}
+			ret = append(ret, d)
 		}
-		ret = append(ret, d)
 	}
 
 	return ret, nil

--- a/plugins/system/ps/disk/disk_test.go
+++ b/plugins/system/ps/disk/disk_test.go
@@ -23,7 +23,7 @@ func TestDisk_usage(t *testing.T) {
 }
 
 func TestDisk_partitions(t *testing.T) {
-	ret, err := DiskPartitions(false)
+	ret, err := DiskPartitions([])
 	if err != nil || len(ret) == 0 {
 		t.Errorf("error %v", err)
 	}

--- a/plugins/system/ps/disk/disk_windows.go
+++ b/plugins/system/ps/disk/disk_windows.go
@@ -55,7 +55,7 @@ func DiskUsage(path string) (DiskUsageStat, error) {
 	return ret, nil
 }
 
-func DiskPartitions(all bool) ([]DiskPartitionStat, error) {
+func DiskPartitions(fstypes []string) ([]DiskPartitionStat, error) {
 	var ret []DiskPartitionStat
 	lpBuffer := make([]byte, 254)
 	diskret, _, err := procGetLogicalDriveStringsW.Call(


### PR DESCRIPTION
When running telegraf initially, it found all the NFS, Lustre, tmpfs, /proc and similar filesystems on the nodes, creating a lot of statistics that were duplicated or of little use.

The config file now takes an array of filesystem types to accept when looking at disk usage:

    fstypes = ["ext4", "xfs"]