### PR TITLE
Add log rotation to /etc/logrotate.d for deb and rpm packages

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -35,8 +35,10 @@ AWS_FILE=~/aws.conf
 INSTALL_ROOT_DIR=/opt/telegraf
 TELEGRAF_LOG_DIR=/var/log/telegraf
 CONFIG_ROOT_DIR=/etc/opt/telegraf
+LOGROTATE_DIR=/etc/logrotate.d
 
 SAMPLE_CONFIGURATION=etc/config.sample.toml
+LOGROTATE_CONFIGURATION=etc/logrotate.d/telegraf
 INITD_SCRIPT=scripts/init.sh
 
 TMP_WORK_DIR=`mktemp -d`
@@ -140,6 +142,11 @@ make_dir_tree() {
         cleanup_exit 1
     fi
     mkdir -p $work_dir/$CONFIG_ROOT_DIR
+    if [ $? -ne 0 ]; then
+        echo "Failed to create configuration directory -- aborting."
+        cleanup_exit 1
+    fi
+    mkdir -p $work_dir/$LOGROTATE_DIR
     if [ $? -ne 0 ]; then
         echo "Failed to create configuration directory -- aborting."
         cleanup_exit 1
@@ -248,6 +255,12 @@ echo "$INITD_SCRIPT copied to $TMP_WORK_DIR/$INSTALL_ROOT_DIR/versions/$VERSION/
 cp $SAMPLE_CONFIGURATION $TMP_WORK_DIR/$CONFIG_ROOT_DIR/telegraf.conf
 if [ $? -ne 0 ]; then
     echo "Failed to copy $SAMPLE_CONFIGURATION to packaging directory -- aborting."
+    cleanup_exit 1
+fi
+
+cp $LOGROTATE_CONFIGURATION $TMP_WORK_DIR/$LOGROTATE_DIR/telegraf.conf
+if [ $? -ne 0 ]; then
+    echo "Failed to copy $LOGROTATE_CONFIGURATION to packaging directory -- aborting."
     cleanup_exit 1
 fi
 


### PR DESCRIPTION
I thought it would be nice to have a default log rotation set up, in case people forget to set it up.