### PR TITLE
Log rotation configuration for rpm/deb

### DIFF
--- a/etc/logrotate.d/telegraf
+++ b/etc/logrotate.d/telegraf
@@ -1,0 +1,10 @@
+/var/log/telegraf/telegraf.log 
+{
+    rotate 6
+    daily
+    missingok
+    notifempty
+    nocreate
+    compress
+}
+

--- a/package.sh
+++ b/package.sh
@@ -35,8 +35,10 @@ AWS_FILE=~/aws.conf
 INSTALL_ROOT_DIR=/opt/telegraf
 TELEGRAF_LOG_DIR=/var/log/telegraf
 CONFIG_ROOT_DIR=/etc/opt/telegraf
+LOGROTATE_DIR=/etc/logrotate.d
 
 SAMPLE_CONFIGURATION=etc/config.sample.toml
+LOGROTATE_CONFIGURATION=etc/logrotate.d/telegraf
 INITD_SCRIPT=scripts/init.sh
 
 TMP_WORK_DIR=`mktemp -d`
@@ -144,6 +146,12 @@ make_dir_tree() {
         echo "Failed to create configuration directory -- aborting."
         cleanup_exit 1
     fi
+    mkdir -p $work_dir/$LOGROTATE_DIR
+    if [ $? -ne 0 ]; then
+        echo "Failed to create configuration directory -- aborting."
+        cleanup_exit 1
+    fi
+
 }
 
 
@@ -248,6 +256,12 @@ echo "$INITD_SCRIPT copied to $TMP_WORK_DIR/$INSTALL_ROOT_DIR/versions/$VERSION/
 cp $SAMPLE_CONFIGURATION $TMP_WORK_DIR/$CONFIG_ROOT_DIR/telegraf.conf
 if [ $? -ne 0 ]; then
     echo "Failed to copy $SAMPLE_CONFIGURATION to packaging directory -- aborting."
+    cleanup_exit 1
+fi
+
+cp $LOGROTATE_CONFIGURATION $TMP_WORK_DIR/$LOGROTATE_DIR/telegraf.conf
+if [ $? -ne 0 ]; then
+    echo "Failed to copy $LOGROTATE_CONFIGURATION to packaging directory -- aborting."
     cleanup_exit 1
 fi
 

--- a/package.sh
+++ b/package.sh
@@ -259,7 +259,7 @@ if [ $? -ne 0 ]; then
     cleanup_exit 1
 fi
 
-cp $LOGROTATE_CONFIGURATION $TMP_WORK_DIR/$LOGROTATE_DIR/telegraf.conf
+cp $LOGROTATE_CONFIGURATION $TMP_WORK_DIR/$LOGROTATE_DIR/telegraf
 if [ $? -ne 0 ]; then
     echo "Failed to copy $LOGROTATE_CONFIGURATION to packaging directory -- aborting."
     cleanup_exit 1


### PR DESCRIPTION
Take 2. The .deb file installs /etc/logrotate.d/telegraf.  I don't have a RedHat based system to test on, but the rpm definitely has the file in it, I've tested with `rpm2cpio telegraf*rpm | cpio -idmv`. 