### PR TITLE
Merge of PR #107, Allow Telegraf to output data to multiple locations beyond InfluxDB, such as Riemann or Kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg/
 tivan
 .vagrant
+telegraf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#98](https://github.com/influxdb/telegraf/pull/98): LeoFS plugin. Thanks @mocchira!
 - [#103](https://github.com/influxdb/telegraf/pull/103): Filter by metric tags. Thanks @srfraser!
 - [#106](https://github.com/influxdb/telegraf/pull/106): Options to filter plugins on startup. Thanks @zepouet!
+- [#107](https://github.com/influxdb/telegraf/pull/107): Multiple outputs beyong influxdb. Thanks @jipperinbham!
 
 ### Bugfixes
 - [#85](https://github.com/influxdb/telegraf/pull/85): Fix GetLocalHost testutil function for mac users

--- a/agent.go
+++ b/agent.go
@@ -10,9 +10,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdb/influxdb/client"
+	"github.com/influxdb/telegraf/outputs"
 	"github.com/influxdb/telegraf/plugins"
 )
+
+type runningOutput struct {
+	name   string
+	output outputs.Output
+}
 
 type runningPlugin struct {
 	name   string
@@ -32,9 +37,8 @@ type Agent struct {
 
 	Config *Config
 
+	outputs []*runningOutput
 	plugins []*runningPlugin
-
-	conn *client.Client
 }
 
 // NewAgent returns an Agent struct based off the given Config
@@ -66,27 +70,37 @@ func NewAgent(config *Config) (*Agent, error) {
 
 // Connect connects to the agent's config URL
 func (a *Agent) Connect() error {
-	config := a.Config
-
-	u, err := url.Parse(config.URL)
-	if err != nil {
-		return err
+	for _, o := range a.outputs {
+		err := o.output.Connect(a.Hostname)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
+}
 
-	c, err := client.NewClient(client.Config{
-		URL:       *u,
-		Username:  config.Username,
-		Password:  config.Password,
-		UserAgent: config.UserAgent,
-		Timeout:   config.Timeout.Duration,
-	})
+func (a *Agent) LoadOutputs() ([]string, error) {
+	var names []string
 
-	if err != nil {
-		return err
+	for _, name := range a.Config.OutputsDeclared() {
+		creator, ok := outputs.Outputs[name]
+		if !ok {
+			return nil, fmt.Errorf("Undefined but requested output: %s", name)
+		}
+
+		output := creator()
+
+		err := a.Config.ApplyOutput(name, output)
+		if err != nil {
+			return nil, err
+		}
+
+		a.outputs = append(a.outputs, &runningOutput{name, output})
+		names = append(names, name)
 	}
 
 	_, err = c.Query(client.Query{
-		Command: fmt.Sprintf("CREATE DATABASE %s", config.Database),
+		Command: fmt.Sprintf("CREATE DATABASE telegraf"),
 	})
 
 	if err != nil && !strings.Contains(err.Error(), "database already exists") {
@@ -95,7 +109,7 @@ func (a *Agent) Connect() error {
 
 	a.conn = c
 
-	return nil
+	return names, nil
 }
 
 // LoadPlugins loads the agent's plugins
@@ -113,6 +127,8 @@ func (a *Agent) LoadPlugins(pluginsFilter string) ([]string, error) {
 		if !ok {
 			return nil, fmt.Errorf("Undefined but requested plugin: %s", name)
 		}
+
+		plugin := creator()
 
 		isPluginEnabled := false
 		if len(filters) > 0 {
@@ -205,8 +221,7 @@ func (a *Agent) crank() error {
 	acc.Time = time.Now()
 	acc.Database = a.Config.Database
 
-	_, err := a.conn.Write(acc.BatchPoints)
-	return err
+	return a.flush(&acc)
 }
 
 func (a *Agent) crankSeparate(shutdown chan struct{}, plugin *runningPlugin) error {
@@ -228,7 +243,10 @@ func (a *Agent) crankSeparate(shutdown chan struct{}, plugin *runningPlugin) err
 		acc.Time = time.Now()
 		acc.Database = a.Config.Database
 
-		a.conn.Write(acc.BatchPoints)
+		err = a.flush(&acc)
+		if err != nil {
+			return err
+		}
 
 		select {
 		case <-shutdown:
@@ -237,6 +255,22 @@ func (a *Agent) crankSeparate(shutdown chan struct{}, plugin *runningPlugin) err
 			continue
 		}
 	}
+}
+
+func (a *Agent) flush(bp *BatchPoints) error {
+	var wg sync.WaitGroup
+	var outerr error
+	for _, o := range a.outputs {
+		wg.Add(1)
+		go func(ro *runningOutput) {
+			defer wg.Done()
+			outerr = ro.output.Write(bp.BatchPoints)
+		}(o)
+	}
+
+	wg.Wait()
+
+	return outerr
 }
 
 // TestAllPlugins verifies that we can 'Gather' from all plugins with the
@@ -297,13 +331,6 @@ func (a *Agent) Test() error {
 
 // Run runs the agent daemon, gathering every Interval
 func (a *Agent) Run(shutdown chan struct{}) error {
-	if a.conn == nil {
-		err := a.Connect()
-		if err != nil {
-			return err
-		}
-	}
-
 	var wg sync.WaitGroup
 
 	for _, plugin := range a.plugins {

--- a/agent.go
+++ b/agent.go
@@ -67,7 +67,7 @@ func NewAgent(config *Config) (*Agent, error) {
 	return agent, nil
 }
 
-// Connect connects to the agent's config URL
+// Connect connects to all configured outputs
 func (a *Agent) Connect() error {
 	for _, o := range a.outputs {
 		err := o.output.Connect()
@@ -76,6 +76,15 @@ func (a *Agent) Connect() error {
 		}
 	}
 	return nil
+}
+
+// Close closes the connection to all configured outputs
+func (a *Agent) Close() error {
+	var err error
+	for _, o := range a.outputs {
+		err = o.output.Close()
+	}
+	return err
 }
 
 // LoadOutputs loads the agent's outputs

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -59,6 +59,11 @@ func main() {
 		ag.Debug = true
 	}
 
+	outputs, err := ag.LoadOutputs()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	plugins, err := ag.LoadPlugins(*fPLuginsFilter)
 	if err != nil {
 		log.Fatal(err)
@@ -99,16 +104,12 @@ func main() {
 	}()
 
 	log.Printf("Starting Telegraf (version %s)\n", Version)
+	log.Printf("Loaded outputs: %s", strings.Join(outputs, " "))
 	log.Printf("Loaded plugins: %s", strings.Join(plugins, " "))
 	if ag.Debug {
 		log.Printf("Debug: enabled")
 		log.Printf("Agent Config: Interval:%s, Debug:%#v, Hostname:%#v\n",
 			ag.Interval, ag.Debug, ag.Hostname)
-	}
-
-	if config.URL != "" {
-		log.Printf("Sending metrics to: %s", config.URL)
-		log.Printf("Tags enabled: %v", config.ListTags())
 	}
 
 	if *fPidfile != "" {

--- a/config.go
+++ b/config.go
@@ -34,6 +34,8 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 // will be logging to, as well as all the plugins that the user has
 // specified
 type Config struct {
+	Tags map[string]string
+
 	agent   *ast.Table
 	plugins map[string]*ast.Table
 	outputs map[string]*ast.Table
@@ -42,10 +44,6 @@ type Config struct {
 // Plugins returns the configured plugins as a map of name -> plugin toml
 func (c *Config) Plugins() map[string]*ast.Table {
 	return c.plugins
-}
-type TagFilter struct {
-	Name   string
-	Filter []string
 }
 
 // Outputs returns the configured outputs as a map of name -> output toml
@@ -66,9 +64,6 @@ type ConfiguredPlugin struct {
 
 	Drop []string
 	Pass []string
-	TagDrop []TagFilter
-
-	TagPass []TagFilter
 
 	TagDrop []TagFilter
 	TagPass []TagFilter
@@ -131,7 +126,8 @@ func (cp *ConfiguredPlugin) ShouldPass(measurement string, tags map[string]strin
 func (c *Config) ApplyOutput(name string, v interface{}) error {
 	if c.outputs[name] != nil {
 		return toml.UnmarshalTable(c.outputs[name], v)
-    }
+	}
+	return nil
 }
 
 // ApplyAgent loads the toml config into the given interface
@@ -246,15 +242,15 @@ func (c *Config) OutputsDeclared() []string {
 }
 
 func declared(endpoints map[string]*ast.Table) []string {
-	var plugins []string
+	var names []string
 
-	for name := range c.plugins {
-		plugins = append(plugins, name)
+	for name := range endpoints {
+		names = append(names, name)
 	}
 
-	sort.Strings(plugins)
+	sort.Strings(names)
 
-	return plugins
+	return names
 }
 
 // DefaultConfig returns an empty default configuration
@@ -376,8 +372,8 @@ database = "telegraf" # required.
 
 # Tags can also be specified via a normal map, but only one form at a time:
 
-# [influxdb.tags]
-# tags = { "dc" = "us-east-1" }
+# [tags]
+# dc = "us-east-1" }
 
 # Configuration for telegraf itself
 # [agent]

--- a/config.go
+++ b/config.go
@@ -34,21 +34,23 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 // will be logging to, as well as all the plugins that the user has
 // specified
 type Config struct {
-	URL       string
-	Username  string
-	Password  string
-	Database  string
-	UserAgent string
-	Timeout   Duration
-	Tags      map[string]string
-
 	agent   *ast.Table
 	plugins map[string]*ast.Table
+	outputs map[string]*ast.Table
 }
 
 // Plugins returns the configured plugins as a map of name -> plugin toml
 func (c *Config) Plugins() map[string]*ast.Table {
 	return c.plugins
+}
+type TagFilter struct {
+	Name   string
+	Filter []string
+}
+
+// Outputs returns the configured outputs as a map of name -> output toml
+func (c *Config) Outputs() map[string]*ast.Table {
+	return c.outputs
 }
 
 // The name of a tag, and the values on which to filter
@@ -64,6 +66,9 @@ type ConfiguredPlugin struct {
 
 	Drop []string
 	Pass []string
+	TagDrop []TagFilter
+
+	TagPass []TagFilter
 
 	TagDrop []TagFilter
 	TagPass []TagFilter
@@ -120,6 +125,13 @@ func (cp *ConfiguredPlugin) ShouldPass(measurement string, tags map[string]strin
 	}
 
 	return true
+}
+
+// ApplyOutput loads the toml config into the given interface
+func (c *Config) ApplyOutput(name string, v interface{}) error {
+	if c.outputs[name] != nil {
+		return toml.UnmarshalTable(c.outputs[name], v)
+    }
 }
 
 // ApplyAgent loads the toml config into the given interface
@@ -225,6 +237,15 @@ func (c *Config) ApplyPlugin(name string, v interface{}) (*ConfiguredPlugin, err
 
 // PluginsDeclared returns the name of all plugins declared in the config.
 func (c *Config) PluginsDeclared() []string {
+	return declared(c.plugins)
+}
+
+// OutputsDeclared returns the name of all outputs declared in the config.
+func (c *Config) OutputsDeclared() []string {
+	return declared(c.outputs)
+}
+
+func declared(endpoints map[string]*ast.Table) []string {
 	var plugins []string
 
 	for name := range c.plugins {
@@ -257,6 +278,7 @@ func LoadConfig(path string) (*Config, error) {
 
 	c := &Config{
 		plugins: make(map[string]*ast.Table),
+		outputs: make(map[string]*ast.Table),
 	}
 
 	for name, val := range tbl.Fields {
@@ -266,13 +288,16 @@ func LoadConfig(path string) (*Config, error) {
 		}
 
 		switch name {
-		case "influxdb":
-			err := toml.UnmarshalTable(subtbl, c)
-			if err != nil {
-				return nil, err
-			}
 		case "agent":
 			c.agent = subtbl
+		case "outputs":
+			for outputName, outputVal := range subtbl.Fields {
+				outputSubtbl, ok := outputVal.(*ast.Table)
+				if !ok {
+					return nil, errInvalidConfig
+				}
+				c.outputs[outputName] = outputSubtbl
+			}
 		default:
 			c.plugins[name] = subtbl
 		}
@@ -327,8 +352,11 @@ var header = `# Telegraf configuration
 # NOTE: The configuration has a few required parameters. They are marked
 # with 'required'. Be sure to edit those to make this configuration work.
 
+# OUTPUTS
+[outputs]
+
 # Configuration for influxdb server to send metrics to
-[influxdb]
+[outputs.influxdb]
 # The full HTTP endpoint URL for your InfluxDB instance
 url = "http://localhost:8086" # required.
 
@@ -345,12 +373,11 @@ database = "telegraf" # required.
 
 # Set the user agent for the POSTs (can be useful for log differentiation)
 # user_agent = "telegraf"
-# tags = { "dc": "us-east-1" }
 
 # Tags can also be specified via a normal map, but only one form at a time:
 
 # [influxdb.tags]
-# dc = "us-east-1"
+# tags = { "dc" = "us-east-1" }
 
 # Configuration for telegraf itself
 # [agent]

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -35,12 +35,11 @@ database = "telegraf" # required.
 
 # Set the user agent for the POSTs (can be useful for log differentiation)
 # user_agent = "telegraf"
-# tags = { "dc": "us-east-1" }
 
 # Tags can also be specified via a normal map, but only one form at a time:
 
 # [influxdb.tags]
-# dc = "us-east-1"
+# tags = { "dc" = "us-east-1" }
 
 # Configuration for telegraf itself
 # [agent]

--- a/outputs/all/all.go
+++ b/outputs/all/all.go
@@ -1,0 +1,5 @@
+package all
+
+import (
+	_ "github.com/influxdb/telegraf/outputs/influxdb"
+)

--- a/outputs/influxdb/influxdb.go
+++ b/outputs/influxdb/influxdb.go
@@ -1,0 +1,67 @@
+package influxdb
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/influxdb/influxdb/client"
+	t "github.com/influxdb/telegraf"
+	"github.com/influxdb/telegraf/outputs"
+)
+
+type InfluxDB struct {
+	URL       string
+	Username  string
+	Password  string
+	Database  string
+	UserAgent string
+	Timeout   t.Duration
+
+	conn *client.Client
+}
+
+func (i *InfluxDB) Connect() error {
+	u, err := url.Parse(i.URL)
+	if err != nil {
+		return err
+	}
+
+	c, err := client.NewClient(client.Config{
+		URL:       *u,
+		Username:  i.Username,
+		Password:  i.Password,
+		UserAgent: i.UserAgent,
+		Timeout:   i.Timeout.Duration,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Query(client.Query{
+		Command: fmt.Sprintf("CREATE DATABASE telegraf"),
+	})
+
+	if err != nil && !strings.Contains(err.Error(), "database already exists") {
+		log.Fatal(err)
+	}
+
+	i.conn = c
+	return nil
+}
+
+func (i *InfluxDB) Write(bp client.BatchPoints) error {
+	bp.Database = i.Database
+	if _, err := i.conn.Write(bp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	outputs.Add("influxdb", func() outputs.Output {
+		return &InfluxDB{}
+	})
+}

--- a/outputs/influxdb/influxdb.go
+++ b/outputs/influxdb/influxdb.go
@@ -52,6 +52,11 @@ func (i *InfluxDB) Connect() error {
 	return nil
 }
 
+func (i *InfluxDB) Close() error {
+	// InfluxDB client does not provide a Close() function
+	return nil
+}
+
 func (i *InfluxDB) Write(bp client.BatchPoints) error {
 	bp.Database = i.Database
 	if _, err := i.conn.Write(bp); err != nil {

--- a/outputs/registry.go
+++ b/outputs/registry.go
@@ -1,0 +1,18 @@
+package outputs
+
+import (
+	"github.com/influxdb/influxdb/client"
+)
+
+type Output interface {
+	Connect() error
+	Write(client.BatchPoints) error
+}
+
+type Creator func() Output
+
+var Outputs = map[string]Creator{}
+
+func Add(name string, creator Creator) {
+	Outputs[name] = creator
+}

--- a/outputs/registry.go
+++ b/outputs/registry.go
@@ -6,6 +6,7 @@ import (
 
 type Output interface {
 	Connect() error
+	Close() error
 	Write(client.BatchPoints) error
 }
 

--- a/testdata/influx.toml
+++ b/testdata/influx.toml
@@ -3,12 +3,15 @@ interval = "5s"
 http = ":11213"
 debug = true
 
-[influxdb]
+[outputs]
+[outputs.influxdb]
 url = "http://localhost:8086"
 username = "root"
 password = "root"
 database = "telegraf"
-tags = { dc = "us-phx-1" }
+
+[tags.influxdb]
+tags = { "dc" = "us-phx-1" }
 
 [redis]
 address = ":6379"

--- a/testdata/influx.toml
+++ b/testdata/influx.toml
@@ -10,8 +10,8 @@ username = "root"
 password = "root"
 database = "telegraf"
 
-[tags.influxdb]
-tags = { "dc" = "us-phx-1" }
+[tags]
+dc = "us-phx-1" }
 
 [redis]
 address = ":6379"

--- a/testdata/telegraf-agent.toml
+++ b/testdata/telegraf-agent.toml
@@ -23,7 +23,8 @@
 # with 'required'. Be sure to edit those to make this configuration work.
 
 # Configuration for influxdb server to send metrics to
-[influxdb]
+[outputs]
+[outputs.influxdb]
 # The full HTTP endpoint URL for your InfluxDB instance
 url = "http://localhost:8086" # required.
 
@@ -40,11 +41,10 @@ database = "telegraf" # required.
 
 # Set the user agent for the POSTs (can be useful for log differentiation)
 # user_agent = "telegraf"
-# tags = { "dc": "us-east-1" }
 
 # Tags can also be specified via a normal map, but only one form at a time:
 
-# [influxdb.tags]
+# [tags]
 # dc = "us-east-1"
 
 # Configuration for telegraf itself
@@ -204,11 +204,11 @@ urls = ["localhost/status"]
 #   postgres://[pqgotest[:password]]@localhost?sslmode=[disable|verify-ca|verify-full]
 # or a simple string:
 #   host=localhost user=pqotest password=... sslmode=...
-# 
+#
 # All connection parameters are optional. By default, the host is localhost
 # and the user is the currently running user. For localhost, we default
 # to sslmode=disable as well.
-# 
+#
 
 address = "sslmode=disable"
 


### PR DESCRIPTION
\cc @jipperinbham @pauldix @toddboom 

This PR supports Telegraf outputting data to multiple locations beyond just InfluxDB. This is a breaking change that requires some changes to the .toml Telegraf configuration file, basically users will need to change their `influxdb` entry from this:

```
[influxdb]
url = "http://localhost:8086"
database = "telegraf"
```

to this

```
[outputs]
[outputs.influxdb]
url = "http://localhost:8086"
database = "telegraf"
```

You can find more details in @jipperinbham's original PR here: https://github.com/influxdb/telegraf/pull/107