### PR TITLE
Fix for issue #121, update etc/config.sample.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ build: prepare
 
 prepare:
 	go get github.com/tools/godep
-	$(GOPATH)/bin/godep go install ./...
 
 docker-compose:
 	docker-compose up -d

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,118 +5,27 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # All Vagrant configuration is done here. The most common configuration
-  # options are documented and commented below. For a complete reference,
-  # please see the online documentation at vagrantup.com.
 
-  # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/trusty64"
+  config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/influxdb/telegraf"
 
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
+  config.vm.provision "shell", name: "sudo", inline: <<-SHELL
+    chown -R vagrant:vagrant /home/vagrant/go
+    apt-get install bison git tig --yes
+    echo -n                                >  /etc/profile.d/gopath.sh
+    echo 'export GOPATH=/home/vagrant/go'  >> /etc/profile.d/gopath.sh
+  SHELL
 
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.provision "shell", privileged: false, name: "user", inline: <<-SHELL
+    bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+    source "$HOME/.gvm/scripts/gvm"
+    gvm install go1.4.2 --prefer-binary
+    gvm use go1.4.2 --default
+    echo "export PATH=$PATH:$GOPATH/bin"   >> "$HOME/.bashrc"
+    cd "$HOME/go/src/github.com/influxdb/telegraf" && make
+  SHELL
 
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # If true, then any SSH connections made will enable agent forwarding.
-  # Default value: false
-  # config.ssh.forward_agent = true
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  config.vm.synced_folder "~/go", "/home/vagrant/go"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
   config.vm.provider "virtualbox" do |vb|
-  #   # Don't boot with headless mode
-  #   vb.gui = true
-  #
-  #   # Use VBoxManage to customize the VM. For example to change memory:
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
-  #
-  # View the documentation for the provider you're using for more
-  # information on available options.
-
-  # Enable provisioning with CFEngine. CFEngine Community packages are
-  # automatically installed. For example, configure the host as a
-  # policy server and optionally a policy file to run:
-  #
-  # config.vm.provision "cfengine" do |cf|
-  #   cf.am_policy_hub = true
-  #   # cf.run_file = "motd.cf"
-  # end
-  #
-  # You can also configure and bootstrap a client to an existing
-  # policy server:
-  #
-  # config.vm.provision "cfengine" do |cf|
-  #   cf.policy_server_address = "10.0.2.15"
-  # end
-
-  # Enable provisioning with Puppet stand alone.  Puppet manifests
-  # are contained in a directory path relative to this Vagrantfile.
-  # You will need to create the manifests directory and a manifest in
-  # the file default.pp in the manifests_path directory.
-  #
-  # config.vm.provision "puppet" do |puppet|
-  #   puppet.manifests_path = "manifests"
-  #   puppet.manifest_file  = "site.pp"
-  # end
-
-  # Enable provisioning with chef solo, specifying a cookbooks path, roles
-  # path, and data_bags path (all relative to this Vagrantfile), and adding
-  # some recipes and/or roles.
-  #
-  # config.vm.provision "chef_solo" do |chef|
-  #   chef.cookbooks_path = "../my-recipes/cookbooks"
-  #   chef.roles_path = "../my-recipes/roles"
-  #   chef.data_bags_path = "../my-recipes/data_bags"
-  #   chef.add_recipe "mysql"
-  #   chef.add_role "web"
-  #
-  #   # You may also specify custom JSON attributes:
-  #   chef.json = { mysql_password: "foo" }
-  # end
-
-  # Enable provisioning with chef server, specifying the chef server URL,
-  # and the path to the validation key (relative to this Vagrantfile).
-  #
-  # The Opscode Platform uses HTTPS. Substitute your organization for
-  # ORGNAME in the URL and validation key.
-  #
-  # If you have your own Chef Server, use the appropriate URL, which may be
-  # HTTP instead of HTTPS depending on your configuration. Also change the
-  # validation key to validation.pem.
-  #
-  # config.vm.provision "chef_client" do |chef|
-  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
-  #   chef.validation_key_path = "ORGNAME-validator.pem"
-  # end
-  #
-  # If you're using the Opscode platform, your validator client is
-  # ORGNAME-validator, replacing ORGNAME with your organization name.
-  #
-  # If you have your own Chef Server, the default validation client name is
-  # chef-validator, unless you changed the configuration.
-  #
-  #   chef.validation_client_name = "ORGNAME-validator"
 end

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -23,7 +23,8 @@
 # with 'required'. Be sure to edit those to make this configuration work.
 
 # Configuration for influxdb server to send metrics to
-[influxdb]
+[outputs]
+[outputs.influxdb]
 # The full HTTP endpoint URL for your InfluxDB instance
 url = "http://localhost:8086" # required.
 
@@ -51,14 +52,13 @@ database = "telegraf" # required.
 
 # Read metrics about cpu usage
 [cpu]
-  # no configuration
+# Whether to report per-cpu stats or not
+percpu = true
+# # Whether to report total system cpu stats or not
+totalcpu = true
 
 # Read metrics about disk usage by mount point
 [disk]
-  # no configuration
-
-# Read metrics about docker containers
-[docker]
   # no configuration
 
 # Read metrics about disk IO by device
@@ -68,74 +68,3 @@ database = "telegraf" # required.
 # Read metrics about memory usage
 [mem]
   # no configuration
-
-# Read metrics from one or many mysql servers
-[mysql]
-
-# specify servers via a url matching:
-#  [username[:password]@][protocol[(address)]]/[?tls=[true|false|skip-verify]]
-#  e.g. root:root@http://10.0.0.18/?tls=false
-#
-# If no servers are specified, then localhost is used as the host.
-servers = ["localhost"]
-
-# Read metrics about network interface usage
-[net]
-
-# By default, telegraf gathers stats from any up interface (excluding loopback)
-# Setting interfaces will tell it to gather these explicit interfaces,
-# regardless of status.
-#
-# interfaces = ["eth0", ... ]
-
-# Read metrics from one or many postgresql servers
-[postgresql]
-
-# specify servers via an array of tables
-[[postgresql.servers]]
-
-# specify address via a url matching:
-#   postgres://[pqgotest[:password]]@localhost?sslmode=[disable|verify-ca|verify-full]
-# or a simple string:
-#   host=localhost user=pqotest password=... sslmode=...
-#
-# All connection parameters are optional. By default, the host is localhost
-# and the user is the currently running user. For localhost, we default
-# to sslmode=disable as well.
-#
-
-address = "sslmode=disable"
-
-# A list of databases to pull metrics about. If not specified, metrics for all
-# databases are gathered.
-
-# databases = ["app_production", "blah_testing"]
-
-# [[postgresql.servers]]
-# address = "influx@remoteserver"
-
-# Read metrics from one or many redis servers
-[redis]
-
-# An array of address to gather stats about. Specify an ip on hostname
-# with optional port. ie localhost, 10.10.3.33:18832, etc.
-#
-# If no servers are specified, then localhost is used as the host.
-servers = ["localhost"]
-
-[mongodb]
-# An array of URI to gather stats about. Specify an ip or hostname
-# with optional port add password. ie mongodb://user:auth_key@10.10.3.30:27017,
-# mongodb://10.10.3.33:18832, 10.0.0.1:10000, etc.
-#
-# If no servers are specified, then 127.0.0.1 is used as the host and 27107 as the port.
-servers = ["127.0.0.1:27017"]
-
-# Read metrics about swap memory usage
-[swap]
-  # no configuration
-
-# Read metrics about system load
-[system]
-  # no configuration
-


### PR DESCRIPTION
@srfraser I believe this will correct issue #121 that you reported today.

I've updated the /etc sample config to be more simple, as well as updating it to use the outputs.influxdb syntax.

I've also updated the Vagrantfile to be more useful for this project, so that I can more easily debug linux problems in future iterations :-)

I appreciate your patience with the packaging problems, I think that using `godep` will make things much easier going forward