### PR TITLE
Fix errors not being logged for plugin.Gather

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.1.7 [unreleased]
 
 ### Features
+ - [#133](https://github.com/influxdb/telegraf/pull/133): Add plugin.Gather error logging. Thanks @nickscript0!
 
 ### Bigfixes
 - [#129](https://github.com/influxdb/telegraf/issues/129): Latest pkg url fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.1.7 [unreleased]
 
 ### Features
- - [#133](https://github.com/influxdb/telegraf/pull/133): Add plugin.Gather error logging. Thanks @nickscript0!
+- [#133](https://github.com/influxdb/telegraf/pull/133): Add plugin.Gather error logging. Thanks @nickscript0!
 
 ### Bigfixes
 - [#129](https://github.com/influxdb/telegraf/issues/129): Latest pkg url fix.

--- a/agent.go
+++ b/agent.go
@@ -181,7 +181,7 @@ func (a *Agent) crankParallel() error {
 
 			err := plugin.plugin.Gather(&acc)
 			if err != nil {
-				log.Printf("Error in plugins: %s", err)
+				log.Printf("Error in plugin [%s]: %s", plugin.name, err)
 			}
 
 			points <- &acc
@@ -338,7 +338,7 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 				defer wg.Done()
 				err := a.crankSeparate(shutdown, plugin)
 				if err != nil {
-					log.Printf("Error in plugins: %s", err)
+					log.Printf("Error in plugin [%s]: %s", plugin.name, err)
 				}
 			}(plugin)
 		}

--- a/agent.go
+++ b/agent.go
@@ -184,7 +184,6 @@ func (a *Agent) crankParallel() error {
 				log.Printf("Error in plugins: %s", err)
 			}
 
-
 			points <- &acc
 		}(plugin)
 	}

--- a/agent.go
+++ b/agent.go
@@ -179,7 +179,11 @@ func (a *Agent) crankParallel() error {
 			acc.Prefix = plugin.name + "_"
 			acc.Config = plugin.config
 
-			plugin.plugin.Gather(&acc)
+			err := plugin.plugin.Gather(&acc)
+			if err != nil {
+				log.Printf("Error in plugins: %s", err)
+			}
+
 
 			points <- &acc
 		}(plugin)
@@ -333,7 +337,10 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 			wg.Add(1)
 			go func(plugin *runningPlugin) {
 				defer wg.Done()
-				a.crankSeparate(shutdown, plugin)
+				err := a.crankSeparate(shutdown, plugin)
+				if err != nil {
+					log.Printf("Error in plugins: %s", err)
+				}
 			}(plugin)
 		}
 	}


### PR DESCRIPTION
Currently if plugin.Gather returns an error it does not show up in the telegraf log. This PR adds logging to show an error in both crankParallel and crankSeparate cases.

For example a misconfigured plugin as follows currently show no errors:
```
[mysql]
servers = ["notlocalhost"]
```

After this fix it shows an error as expected:
```
./telegraf -config /etc/opt/telegraf/telegraf.conf
2015/08/22 20:48:07 Starting Telegraf
2015/08/22 20:48:07 Loaded outputs: influxdb
2015/08/22 20:48:07 Loaded plugins: cpu mysql
2015/08/22 20:48:07 Tags enabled: dc=test1 host=a11790
2015/08/22 20:48:07 Error in plugins: Invalid DSN: Missing the slash separating the database name
```