### PR TITLE
Typo: prec -> perc

### DIFF
--- a/plugins/system/memory.go
+++ b/plugins/system/memory.go
@@ -27,7 +27,7 @@ func (s *MemStats) Gather(acc plugins.Accumulator) error {
 	acc.Add("total", vm.Total, vmtags)
 	acc.Add("available", vm.Available, vmtags)
 	acc.Add("used", vm.Used, vmtags)
-	acc.Add("used_prec", vm.UsedPercent, vmtags)
+	acc.Add("used_perc", vm.UsedPercent, vmtags)
 	acc.Add("free", vm.Free, vmtags)
 	acc.Add("active", vm.Active, vmtags)
 	acc.Add("inactive", vm.Inactive, vmtags)

--- a/plugins/system/system_test.go
+++ b/plugins/system/system_test.go
@@ -310,7 +310,7 @@ func TestSystemStats_GenerateStats(t *testing.T) {
 	assert.True(t, acc.CheckTaggedValue("total", uint64(12400), vmtags))
 	assert.True(t, acc.CheckTaggedValue("available", uint64(7600), vmtags))
 	assert.True(t, acc.CheckTaggedValue("used", uint64(5000), vmtags))
-	assert.True(t, acc.CheckTaggedValue("used_prec", float64(47.1), vmtags))
+	assert.True(t, acc.CheckTaggedValue("used_perc", float64(47.1), vmtags))
 	assert.True(t, acc.CheckTaggedValue("free", uint64(1235), vmtags))
 	assert.True(t, acc.CheckTaggedValue("active", uint64(8134), vmtags))
 	assert.True(t, acc.CheckTaggedValue("inactive", uint64(1124), vmtags))


### PR DESCRIPTION
I think it's a typo since swap is using `perc`. https://github.com/influxdb/telegraf/blob/8d6b33342d69b9bf8624b1c6f02a454728a6b3f8/plugins/system/memory.go#L63

Do I need to update the changelog for this?