### PR TITLE
Write data in UTC by default and use 's' precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## v0.1.8 [unreleased]
 
+### Release Notes
+Telegraf will now write data in UTC at second precision by default
+
 ### Features
 - [#150](https://github.com/influxdb/telegraf/pull/150): Add Host Uptime metric to system plugin
 - [#158](https://github.com/influxdb/telegraf/pull/158): Apache Plugin. Thanks @KPACHbIuLLIAnO4
+- [#159](https://github.com/influxdb/telegraf/pull/159): Use second precision for InfluxDB writes
 - [#165](https://github.com/influxdb/telegraf/pull/165): Add additional metrics to mysql plugin. Thanks @nickscript0
+- [#162](https://github.com/influxdb/telegraf/pull/162): Write UTC by default, provide option
 - [#166](https://github.com/influxdb/telegraf/pull/166): Upload binaries to S3
 
 ### Bugfixes

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -126,8 +126,9 @@ func main() {
 	log.Printf("Loaded plugins: %s", strings.Join(plugins, " "))
 	if ag.Debug {
 		log.Printf("Debug: enabled")
-		log.Printf("Agent Config: Interval:%s, Debug:%#v, Hostname:%#v\n",
-			ag.Interval, ag.Debug, ag.Hostname)
+		log.Printf("Agent Config: Interval:%s, Debug:%#v, Hostname:%#v, "+
+			"Precision:%#v, UTC: %#v\n",
+			ag.Interval, ag.Debug, ag.Hostname, ag.Precision, ag.UTC)
 	}
 	log.Printf("Tags enabled: %s", config.ListTags())
 

--- a/config.go
+++ b/config.go
@@ -131,10 +131,11 @@ func (c *Config) ApplyOutput(name string, v interface{}) error {
 	return nil
 }
 
-// ApplyAgent loads the toml config into the given interface
-func (c *Config) ApplyAgent(v interface{}) error {
+// ApplyAgent loads the toml config into the given Agent object, overriding
+// defaults (such as collection duration) with the values from the toml config.
+func (c *Config) ApplyAgent(a *Agent) error {
 	if c.agent != nil {
-		return toml.UnmarshalTable(c.agent, v)
+		return toml.UnmarshalTable(c.agent, a)
 	}
 
 	return nil
@@ -350,11 +351,23 @@ var header = `# Telegraf configuration
 [tags]
 	# dc = "us-east-1"
 
-# Configuration for telegraf itself
+# Configuration for telegraf agent
 [agent]
-	# interval = "10s"
-	# debug = false
-	# hostname = "prod3241"
+	# Default data collection interval for all plugins
+	interval = "10s"
+
+	# If utc = false, uses local time (utc is highly recommended)
+	utc = true
+
+	# Precision of writes, valid values are n, u, ms, s, m, and h
+	# note: using second precision greatly helps InfluxDB compression
+	precision = "s"
+
+	# run telegraf in debug mode
+	debug = false
+
+	# Override default hostname, if empty use os.Hostname()
+	hostname = ""
 
 
 ###############################################################################


### PR DESCRIPTION
Closes #159
Closes #162

/cc @pauldix second precision writes
/cc @beckettsean write data in UTC by default, provide option for local