### PR TITLE
More mysql metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## v0.1.8 [unreleased]
 
 ### Features
-
-[#150](https://github.com/influxdb/telegraf/pull/150): Add Host Uptime metric to system plugin
-[#158](https://github.com/influxdb/telegraf/pull/158): Apache Plugin. Thanks @KPACHbIuLLIAnO4
+- [#150](https://github.com/influxdb/telegraf/pull/150): Add Host Uptime metric to system plugin
+- [#158](https://github.com/influxdb/telegraf/pull/158): Apache Plugin. Thanks @KPACHbIuLLIAnO4
+- [#165](https://github.com/influxdb/telegraf/pull/165): Add additional metrics to mysql plugin. Thanks @nickscript0
 
 ### Bugfixes
 

--- a/plugins/mysql/mysql.go
+++ b/plugins/mysql/mysql.go
@@ -59,6 +59,10 @@ type mapping struct {
 
 var mappings = []*mapping{
 	{
+		onServer: "Aborted_",
+		inExport: "aborted_",
+	},
+	{
 		onServer: "Bytes_",
 		inExport: "bytes_",
 	},
@@ -67,12 +71,36 @@ var mappings = []*mapping{
 		inExport: "commands_",
 	},
 	{
+		onServer: "Created_",
+		inExport: "created_",
+	},
+	{
 		onServer: "Handler_",
 		inExport: "handler_",
 	},
 	{
 		onServer: "Innodb_",
 		inExport: "innodb_",
+	},
+	{
+		onServer: "Key_",
+		inExport: "key_",
+	},
+	{
+		onServer: "Open_",
+		inExport: "open_",
+	},
+	{
+		onServer: "Opened_",
+		inExport: "opened_",
+	},
+	{
+		onServer: "Qcache_",
+		inExport: "qcache_",
+	},
+	{
+		onServer: "Table_",
+		inExport: "table_",
 	},
 	{
 		onServer: "Tokudb_",

--- a/plugins/mysql/mysql_test.go
+++ b/plugins/mysql/mysql_test.go
@@ -33,6 +33,13 @@ func TestMysqlGeneratesMetrics(t *testing.T) {
 		{"bytes", 2},
 		{"innodb", 51},
 		{"threads", 4},
+		{"aborted", 2},
+		{"created", 3},
+		{"key", 7},
+		{"open", 7},
+		{"opened", 3},
+		{"qcache", 8},
+		{"table", 5},
 	}
 
 	intMetrics := []string{


### PR DESCRIPTION
This PR adds additional MySQL metrics to the mysql plugin. These additional measurements can be filtered out using the pass/drop filters in case there is a concern around storing more data.

I updated mysql_test.go with the new mappings and "make test" passes for me.