### PR TITLE
package.sh: upload raw binaries to S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#150](https://github.com/influxdb/telegraf/pull/150): Add Host Uptime metric to system plugin
 - [#158](https://github.com/influxdb/telegraf/pull/158): Apache Plugin. Thanks @KPACHbIuLLIAnO4
 - [#165](https://github.com/influxdb/telegraf/pull/165): Add additional metrics to mysql plugin. Thanks @nickscript0
+- [#166](https://github.com/influxdb/telegraf/pull/166): Upload binaries to S3
 
 ### Bugfixes
 


### PR DESCRIPTION
/cc @beckettsean @gunnaraasen how do we feel about distributing linux binaries of telegraf? I was thinking that this might be good for people who want to try out telegraf without installing a .deb or .rpm which also installs an init service on the server.

Also nice for people who just want to manage the service themselves