### PR TITLE
Add a server name tag to the RabbitMQ server list

### DIFF
--- a/plugins/rabbitmq/rabbitmq.go
+++ b/plugins/rabbitmq/rabbitmq.go
@@ -14,6 +14,7 @@ const DefaultURL = "http://localhost:15672"
 
 type Server struct {
 	URL      string
+	Name     string
 	Username string
 	Password string
 	Nodes    []string
@@ -70,6 +71,7 @@ type Node struct {
 var sampleConfig = `
 	# Specify servers via an array of tables
 	[[rabbitmq.servers]]
+	# name = "rmq-server-1" # optional tag
 	# url = "http://localhost:15672"
 	# username = "guest"
 	# password = "guest"
@@ -117,7 +119,10 @@ func (r *RabbitMQ) gatherServer(serv *Server, acc plugins.Accumulator) error {
 		return err
 	}
 
-	tags := map[string]string{}
+	tags := map[string]string{"url": serv.URL}
+	if serv.Name != "" {
+		tags["name"] = serv.Name
+	}
 
 	acc.Add("messages", overview.QueueTotals.Messages, tags)
 	acc.Add("messages_ready", overview.QueueTotals.MessagesReady, tags)
@@ -147,7 +152,7 @@ func (r *RabbitMQ) gatherServer(serv *Server, acc plugins.Accumulator) error {
 			continue
 		}
 
-		tags = map[string]string{"node": node.Name}
+		tags["node"] = node.Name
 
 		acc.Add("disk_free", node.DiskFree, tags)
 		acc.Add("disk_free_limit", node.DiskFreeLimit, tags)

--- a/plugins/system/ps/net/net_darwin.go
+++ b/plugins/system/ps/net/net_darwin.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/common"
+	"github.com/influxdb/telegraf/plugins/system/ps/common"
 )
 
 func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
@@ -26,7 +26,7 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 			// skip first line
 			continue
 		}
-		if common.StringsHas(exists, values[0]) {
+		if common.StringContains(exists, values[0]) {
 			// skip if already get
 			continue
 		}


### PR DESCRIPTION
Fixes #183 

@rvrignaud Adding a configuration tag for the rabbitmq server, as well as adding in the URL tag, let me know if this does it