### PR TITLE
Create PostgreSQL metrics dynamically for older version compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ will still be backwards compatible if only `url` is specified.
 - [#178](https://github.com/influxdb/telegraf/issues/178): redis plugin, multiple server thread hang bug
 - Fix net plugin on darwin
 - [#84](https://github.com/influxdb/telegraf/issues/84): Fix docker plugin on CentOS. Thanks @neezgee!
+- [#192](https://github.com/influxdb/telegraf/issues/192): Increase compatibility of postgresql plugin. Now supports versions 8.1+
 
 ## v0.1.8 [2015-09-04]
 

--- a/plugins/postgresql/README.md
+++ b/plugins/postgresql/README.md
@@ -1,0 +1,30 @@
+# PostgreSQL plugin
+
+This postgresql plugin provides metrics for your postgres database. It currently works with postgres versions 8.1+. It uses data from the built in _pg_stat_database_ view. The metrics recorded depend on your version of postgres. See table:
+```
+pg version      9.2+   9.1   8.3-9.0   8.1-8.2   7.4-8.0(unsupported)
+---             ---    ---   -------   -------   -------
+datid*           x      x       x         x
+datname*         x      x       x         x
+numbackends      x      x       x         x         x
+xact_commit      x      x       x         x         x
+xact_rollback    x      x       x         x         x
+blks_read        x      x       x         x         x
+blks_hit         x      x       x         x         x
+tup_returned     x      x       x
+tup_fetched      x      x       x
+tup_inserted     x      x       x
+tup_updated      x      x       x
+tup_deleted      x      x       x
+conflicts        x      x
+temp_files       x
+temp_bytes       x
+deadlocks        x
+blk_read_time    x
+blk_write_time   x
+stats_reset*     x      x
+```
+
+_* value ignored and therefore not recorded._
+
+More information about the meaning of these metrics can be found in the [PostgreSQL Documentation](http://www.postgresql.org/docs/9.2/static/monitoring-stats.html#PG-STAT-DATABASE-VIEW)

--- a/plugins/postgresql/postgresql.go
+++ b/plugins/postgresql/postgresql.go
@@ -33,10 +33,11 @@ var sampleConfig = `
 	# All connection parameters are optional. By default, the host is localhost
 	# and the user is the currently running user. For localhost, we default
 	# to sslmode=disable as well.
-    # Without the dbname parameter, the driver will default to a database
-    # with the same name as the user. This dbname is just for instantiating a
-    # connection with the server and doesn't restrict the databases we are trying
-    # to grab metrics for.
+	#
+	# Without the dbname parameter, the driver will default to a database
+	# with the same name as the user. This dbname is just for instantiating a
+	# connection with the server and doesn't restrict the databases we are trying
+	# to grab metrics for.
 	#
 
 	address = "sslmode=disable"

--- a/plugins/postgresql/postgresql.go
+++ b/plugins/postgresql/postgresql.go
@@ -26,13 +26,17 @@ var sampleConfig = `
 	[[postgresql.servers]]
 
 	# specify address via a url matching:
-	#   postgres://[pqgotest[:password]]@localhost?sslmode=[disable|verify-ca|verify-full]
+	#   postgres://[pqgotest[:password]]@localhost[/dbname]?sslmode=[disable|verify-ca|verify-full]
 	# or a simple string:
-	#   host=localhost user=pqotest password=... sslmode=...
+	#   host=localhost user=pqotest password=... sslmode=... dbname=app_production
 	#
 	# All connection parameters are optional. By default, the host is localhost
 	# and the user is the currently running user. For localhost, we default
 	# to sslmode=disable as well.
+    # Without the dbname parameter, the driver will default to a database
+    # with the same name as the user. This dbname is just for instantiating a
+    # connection with the server and doesn't restrict the databases we are trying
+    # to grab metrics for.
 	#
 
 	address = "sslmode=disable"

--- a/plugins/postgresql/postgresql_test.go
+++ b/plugins/postgresql/postgresql_test.go
@@ -156,14 +156,7 @@ func TestPostgresqlIgnoresUnwantedColumns(t *testing.T) {
 	err := p.Gather(&acc)
 	require.NoError(t, err)
 
-	var found bool
-
-	for _, pnt := range acc.Points {
-		if pnt.Measurement == "datname" || pnt.Measurement == "datid" || pnt.Measurement == "stats_reset" {
-			found = true
-			break
-		}
+	for col := range p.IgnoredColumns() {
+		assert.False(t, acc.HasMeasurement(col))
 	}
-
-	assert.False(t, found)
 }

--- a/plugins/postgresql/postgresql_test.go
+++ b/plugins/postgresql/postgresql_test.go
@@ -117,3 +117,34 @@ func TestPostgresqlDefaultsToAllDatabases(t *testing.T) {
 
 	assert.True(t, found)
 }
+
+func TestPostgresqlIgnoresUnwantedColumns(t *testing.T) {
+	// if testing.Short() {
+	// 	t.Skip("Skipping integration test in short mode")
+	// }
+
+	p := &Postgresql{
+		Servers: []*Server{
+			{
+				Address: fmt.Sprintf("host=%s user=postgres sslmode=disable",
+					testutil.GetLocalHost()),
+			},
+		},
+	}
+
+	var acc testutil.Accumulator
+
+	err := p.Gather(&acc)
+	require.NoError(t, err)
+
+	var found bool
+
+	for _, pnt := range acc.Points {
+		if pnt.Measurement == "datname" || pnt.Measurement == "datid" || pnt.Measurement == "stats_reset" {
+			found = true
+			break
+		}
+	}
+
+	assert.False(t, found)
+}

--- a/plugins/postgresql/postgresql_test.go
+++ b/plugins/postgresql/postgresql_test.go
@@ -119,9 +119,9 @@ func TestPostgresqlDefaultsToAllDatabases(t *testing.T) {
 }
 
 func TestPostgresqlIgnoresUnwantedColumns(t *testing.T) {
-	// if testing.Short() {
-	// 	t.Skip("Skipping integration test in short mode")
-	// }
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 
 	p := &Postgresql{
 		Servers: []*Server{


### PR DESCRIPTION
The current postgresql plugin only works with postgres versions 9.2+ due to lack of some columns in versions older than that. This PR fixes that by dynamically creating metrics based on the columns returned from the pg_stat_database table.