### PR TITLE
Check if file exists before running disk usage on it.

### DIFF
--- a/plugins/system/ps.go
+++ b/plugins/system/ps.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	gonet "net"
+	"os"
 	"strings"
 
 	dc "github.com/fsouza/go-dockerclient"
@@ -71,12 +72,14 @@ func (s *systemPS) DiskUsage() ([]*disk.DiskUsageStat, error) {
 	var usage []*disk.DiskUsageStat
 
 	for _, p := range parts {
-		du, err := disk.DiskUsage(p.Mountpoint)
-		if err != nil {
-			return nil, err
+		if _, err := os.Stat(p.Mountpoint); err == nil {
+			du, err := disk.DiskUsage(p.Mountpoint)
+			if err != nil {
+				return nil, err
+			}
+			du.Fstype = p.Fstype
+			usage = append(usage, du)
 		}
-		du.Fstype = p.Fstype
-		usage = append(usage, du)
 	}
 
 	return usage, nil


### PR DESCRIPTION
Check if file exists before running disk usage on it. Not all mounts are normal files.

I am running telegraf on an openstack cluster which uses openvswitch which creates mounts for network namespaces that look like this:

    proc net:[4026532152] proc rw,nosuid,nodev,noexec,relatime 0 0

Telegraf fails for disk usage checks whenever this proc is present. The solution is simply to ignore any mounts that don't exist as normal files.