### PR TITLE
Add timestamps to points in Kafka/AMQP outputs

### DIFF
--- a/outputs/amqp/amqp.go
+++ b/outputs/amqp/amqp.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/influxdb/influxdb/client"
 	"github.com/influxdb/telegraf/outputs"
@@ -72,6 +73,7 @@ func (q *AMQP) Write(bp client.BatchPoints) error {
 		return nil
 	}
 
+	var zero_time time.Time
 	for _, p := range bp.Points {
 		// Combine tags from Point and BatchPoints and grab the resulting
 		// line-protocol output string to write to AMQP
@@ -84,6 +86,13 @@ func (q *AMQP) Write(bp client.BatchPoints) error {
 					p.Tags = make(map[string]string, len(bp.Tags))
 				}
 				p.Tags[k] = v
+			}
+			if p.Time == zero_time {
+				if bp.Time == zero_time {
+					p.Time = time.Now()
+				} else {
+					p.Time = bp.Time
+				}
 			}
 			value = p.MarshalString()
 		}

--- a/outputs/kafka/kafka.go
+++ b/outputs/kafka/kafka.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/influxdb/influxdb/client"
@@ -56,6 +57,7 @@ func (k *Kafka) Write(bp client.BatchPoints) error {
 		return nil
 	}
 
+	var zero_time time.Time
 	for _, p := range bp.Points {
 		// Combine tags from Point and BatchPoints and grab the resulting
 		// line-protocol output string to write to Kafka
@@ -68,6 +70,13 @@ func (k *Kafka) Write(bp client.BatchPoints) error {
 					p.Tags = make(map[string]string, len(bp.Tags))
 				}
 				p.Tags[k] = v
+			}
+			if p.Time == zero_time {
+				if bp.Time == zero_time {
+					p.Time = time.Now()
+				} else {
+					p.Time = bp.Time
+				}
 			}
 			value = p.MarshalString()
 		}


### PR DESCRIPTION
I noticed that metrics sent to message queue don't contain timestamps.
It looks like an error, so I've fixed it.

If a point doesn't contain timestamp, then the code checks for bp.Timestamp. If it's also empty, then it uses time.Now().