### PR TITLE
Fix packages provides: now new version of package replaces the old one

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -277,7 +277,7 @@ fi
 
 COMMON_FPM_ARGS="-C $TMP_WORK_DIR --vendor $VENDOR --url $URL --license $LICENSE \
                 --maintainer $MAINTAINER --after-install $POST_INSTALL_PATH \
-                --name telegraf --version $VERSION --config-files $CONFIG_ROOT_DIR ."
+                --name telegraf --provides telegraf --version $VERSION --config-files $CONFIG_ROOT_DIR ."
 $rpm_args fpm -s dir -t rpm --description "$DESCRIPTION" $COMMON_FPM_ARGS
 if [ $? -ne 0 ]; then
     echo "Failed to create RPM package -- aborting."


### PR DESCRIPTION
I'm not sure whether it was planned or not, but I think fpm should have "--provides" option