### PR TITLE
Fix conditional test against useradd so it's compatible with Dash

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -149,7 +149,7 @@ ln -sfn $INSTALL_ROOT_DIR/versions/$version/telegraf $INSTALL_ROOT_DIR/telegraf
 if ! id telegraf >/dev/null 2>&1; then
     useradd --help 2>&1| grep -- --system > /dev/null 2>&1
     old_useradd=\$?
-    if [[ \$old_useradd == 0 ]]
+    if [ \$old_useradd -eq 0 ]
     then
         useradd --system -U -M telegraf
     else


### PR DESCRIPTION
The test to see which version of `useradd` is installed uses 'bashisms' that fail on Ubuntu due to the fact that `/bin/sh` is symlinked to Dash, causing the telegraf account to be created without the `--system` option ever being passed.

This change amends the syntax so that it's POSIX-compatible and more portable as a result.  Fixes #231.