### PR TITLE
Make AddFieldsWithTime usable

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -103,60 +103,22 @@ func (bp *BatchPoints) Add(
 	})
 }
 
-// AddFieldsWithTime adds a measurement with a provided timestamp
-func (bp *BatchPoints) AddFieldsWithTime(
-	measurement string,
-	fields map[string]interface{},
-	tags map[string]string,
-	timestamp time.Time,
-) {
-	// TODO this function should add the fields with the timestamp, but that will
-	// need to wait for the InfluxDB point precision/unit to be fixed
-	bp.AddFields(measurement, fields, tags)
-	// bp.mu.Lock()
-	// defer bp.mu.Unlock()
-
-	// measurement = bp.Prefix + measurement
-
-	// if bp.Config != nil {
-	// 	if !bp.Config.ShouldPass(measurement, tags) {
-	// 		return
-	// 	}
-	// }
-
-	// if bp.Debug {
-	// 	var tg []string
-
-	// 	for k, v := range tags {
-	// 		tg = append(tg, fmt.Sprintf("%s=\"%s\"", k, v))
-	// 	}
-
-	// 	var vals []string
-
-	// 	for k, v := range fields {
-	// 		vals = append(vals, fmt.Sprintf("%s=%v", k, v))
-	// 	}
-
-	// 	sort.Strings(tg)
-	// 	sort.Strings(vals)
-
-	// 	fmt.Printf("> [%s] %s %s\n", strings.Join(tg, " "), measurement, strings.Join(vals, " "))
-	// }
-
-	// bp.Points = append(bp.Points, client.Point{
-	// 	Measurement: measurement,
-	// 	Tags:        tags,
-	// 	Fields:      fields,
-	// 	Time:        timestamp,
-	// })
-}
-
 // AddFields will eventually replace the Add function, once we move to having a
 // single plugin as a single measurement with multiple fields
 func (bp *BatchPoints) AddFields(
 	measurement string,
 	fields map[string]interface{},
 	tags map[string]string,
+) {
+	bp.AddFieldsWithTime(measurement, fields, tags, time.Time{})
+}
+
+// AddFieldsWithTime adds a measurement with a provided timestamp
+func (bp *BatchPoints) AddFieldsWithTime(
+	measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	timestamp time.Time,
 ) {
 	bp.mu.Lock()
 	defer bp.mu.Unlock()
@@ -192,5 +154,6 @@ func (bp *BatchPoints) AddFields(
 		Measurement: measurement,
 		Tags:        tags,
 		Fields:      fields,
+		Time:        timestamp,
 	})
 }


### PR DESCRIPTION
I want to use fields with timestamp in my plugin, but it requires working AddFieldsWithTime.

Since https://github.com/influxdb/influxdb/pull/4105 has been merged, and hopefully it fixes the problem, can we get the function back?