### PR TITLE
Fix for init script for other procs with "telegraf"

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -59,14 +59,17 @@ function pidofproc() {
         echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
     fi
 
-    pid=`pgrep -f $3`
+    if [ ! -f "$2" ]; then
+        return 1
+    fi
+
     local pidfile=`cat $2`
 
     if [ "x$pidfile" == "x" ]; then
         return 1
     fi
 
-    if [ "x$pid" != "x" -a "$pidfile" == "$pid" ]; then
+    if ps --pid "$pidfile" | grep -q $(basename $3); then
         return 0
     fi
 


### PR DESCRIPTION
Fix for #266 

The init script fails if another process has the word "telegraf" in
it, for example if you aren running "vi /etc/opt/telegraf/telegraf.conf"
or "tail -f /var/log/telegraf/telegraf.log".  This is because
the "-f" flag to "pgrep" will show processes with the search
string anywhere in the command-line.

This patch turns it around and gets the "ps" output for the process
in the pidfile, and if that line has "telegraf" in it, it considers
it to be running.