### PR TITLE
[Fix #190] Add httpjson tags support

### DIFF
--- a/plugins/httpjson/README.md
+++ b/plugins/httpjson/README.md
@@ -1,0 +1,69 @@
+# HTTP JSON Plugin
+
+The httpjson plugin can collect data from remote URLs which respond with JSON. Then it flattens JSON and finds all numeric values, treating them as floats.
+
+For example, if you have a service called _mycollector_, which has HTTP endpoint for gathering stats http://my.service.com/_stats:
+
+```
+[[httpjson.services]]
+  name = "mycollector"
+
+  servers = [
+    "http://my.service.com/_stats"
+  ]
+
+  # HTTP method to use (case-sensitive)
+  method = "GET"
+```
+
+The name is used as a prefix for the measurements.
+
+The `method` specifies HTTP method to use for requests.
+
+You can specify which keys from server response should be considered as tags:
+
+```
+[[httpjson.services]]
+  ...
+
+  tagKeys = [
+    "role",
+    "version"
+  ]
+```
+
+**NOTE**: tag values should be strings.
+
+You can also specify additional request parameters for the service:
+
+```
+[[httpjson.services]]
+  ...
+
+ [httpjson.services.parameters]
+    event_type = "cpu_spike"
+    threshold = "0.75"
+
+```
+
+
+# Sample
+
+Let's say that we have a service named "mycollector", which responds with:
+```json
+{
+    "a": 0.5,
+    "b": {
+        "c": "some text",
+        "d": 0.1,
+        "e": 5
+    }
+}
+```
+
+The collected metrics will be:
+```
+httpjson_mycollector_a value=0.5
+httpjson_mycollector_b_d value=0.1
+httpjson_mycollector_b_e value=5
+```

--- a/plugins/httpjson/httpjson.go
+++ b/plugins/httpjson/httpjson.go
@@ -22,7 +22,7 @@ type Service struct {
 	Name       string
 	Servers    []string
 	Method     string
-	Tags       []string
+	TagKeys       []string
 	Parameters map[string]string
 }
 
@@ -63,10 +63,10 @@ var sampleConfig = `
     method = "GET"
 
     # List of tag names to extract from server response
-    tags = [
-    	"my_tag_1",
-    	"my_tag_2"
-    ]
+    # tagKeys = [
+    # 	"my_tag_1",
+    # 	"my_tag_2"
+    # ]
 
     # HTTP parameters (all values must be strings)
     [httpjson.services.parameters]
@@ -142,7 +142,7 @@ func (h *HttpJson) gatherServer(acc plugins.Accumulator, service Service, server
 		"server": serverURL,
 	}
 
-	for _, tag := range service.Tags {
+	for _, tag := range service.TagKeys {
 		switch v := jsonOut[tag].(type) {
 			case string:
 		    tags[tag] = v

--- a/plugins/httpjson/httpjson.go
+++ b/plugins/httpjson/httpjson.go
@@ -22,7 +22,7 @@ type Service struct {
 	Name       string
 	Servers    []string
 	Method     string
-	TagKeys       []string
+	TagKeys    []string
 	Parameters map[string]string
 }
 
@@ -144,8 +144,8 @@ func (h *HttpJson) gatherServer(acc plugins.Accumulator, service Service, server
 
 	for _, tag := range service.TagKeys {
 		switch v := jsonOut[tag].(type) {
-			case string:
-		    tags[tag] = v
+		case string:
+			tags[tag] = v
 		}
 		delete(jsonOut, tag)
 	}

--- a/plugins/httpjson/httpjson_test.go
+++ b/plugins/httpjson/httpjson_test.go
@@ -104,7 +104,7 @@ func genMockHttpJson(response string, statusCode int) *HttpJson {
 					"httpParam1": "12",
 					"httpParam2": "the second parameter",
 				},
-				Tags: []string{
+				TagKeys: []string{
 					"role",
 					"build",
 				},

--- a/plugins/httpjson/httpjson_test.go
+++ b/plugins/httpjson/httpjson_test.go
@@ -35,7 +35,6 @@ const validJSONTags = `
 		"build": "123"
 	}`
 
-
 const invalidJSON = "I don't think this is JSON"
 
 const empty = ""


### PR DESCRIPTION
Tags are extracted from JSON response according to the list of tags in config.

Example:

```toml
# config
[httpjson.services]
  tagKeys = [
    "role",
    "build"
  ]
```
```json
# server response
{
  "value": 123,
  "role": "master",
  "build": "2015"
}
```

And resulting point will contain values `value: 123` and tags `role: master  build: 2015  server_name: ...`.
