### PR TITLE
Add locking to test accumulator

### DIFF
--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"time"
+	"sync"
 )
 
 // Point defines a single point measurement
@@ -16,11 +17,14 @@ type Point struct {
 
 // Accumulator defines a mocked out accumulator
 type Accumulator struct {
+	sync.Mutex
 	Points []*Point
 }
 
 // Add adds a measurement point to the accumulator
 func (a *Accumulator) Add(measurement string, value interface{}, tags map[string]string) {
+	a.Lock()
+	defer a.Unlock()
 	if tags == nil {
 		tags = map[string]string{}
 	}


### PR DESCRIPTION
Some test add points to accumulator in parallel (and sometimes these tests [fail](https://circleci.com/gh/influxdb/telegraf/765)).

This PR just add locking to test accumulator (thus making more compliant with _real_ accumulator).