### PR TITLE
Combine BatchPoints with the same RoutingTag to one message in amqp output

### DIFF
--- a/outputs/amqp/README.md
+++ b/outputs/amqp/README.md
@@ -4,5 +4,6 @@ This plugin writes to a AMQP exchange using tag, defined in configuration file
 as RoutingTag, as a routing key.
 
 If RoutingTag is empty, then empty routing key will be used.
+Metrics are grouped in batches by RoutingTag.
 
 This plugin doesn't bind exchange to a queue, so it should be done by consumer.


### PR DESCRIPTION
After some testing, I've found that 80 hosts can generate up to 11k messages per second and send it to rabbitmq, which is quite a lot!
So let's do some batching.

Also, according to https://www.rabbitmq.com/blog/2012/04/25/rabbitmq-performance-measurements-part-2/

> Quite a lot of the work done by RabbitMQ is per-message, not per-byte-of-message.

Which seems logical.

So this commit uses []byte to accumulate output. It also honours RoutingTag.

Just a few numbers:
80 hosts, recent telegraf, only system metrics.
Before: 11k msg/s (peaked), LA on influxdb host >3 (4 processors)
After: 3k msg/s, LA on influxdb host ~ 0.15