### PR TITLE
Update kafka reamde and improve intergration tests

### DIFF
--- a/plugins/kafka_consumer/README.md
+++ b/plugins/kafka_consumer/README.md
@@ -9,16 +9,16 @@ from the same topic in parallel.
 ## Testing
 
 Running integration tests requires running Zookeeper & Kafka. The following
-commands assume you're on OS X & using [boot2docker](http://boot2docker.io/).
+commands assume you're on OS X & using [boot2docker](http://boot2docker.io/) or docker-machine through [Docker Toolbox](https://www.docker.com/docker-toolbox).
 
 To start Kafka & Zookeeper:
 
 ```
-docker run -d -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=`boot2docker ip` --env ADVERTISED_PORT=9092 spotify/kafka
+docker run -d -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=`boot2docker ip || docker-machine ip <your_machine_name>` --env ADVERTISED_PORT=9092 spotify/kafka
 ```
 
 To run tests:
 
 ```
-ZOOKEEPER_PEERS=$(boot2docker ip):2181 KAFKA_PEERS=$(boot2docker ip):9092 go test
+go test
 ```

--- a/plugins/kafka_consumer/kafka_consumer_integration_test.go
+++ b/plugins/kafka_consumer/kafka_consumer_integration_test.go
@@ -29,7 +29,10 @@ func TestReadsMetricsFromKafka(t *testing.T) {
 	msg := "cpu_load_short,direction=in,host=server01,region=us-west value=23422.0 1422568543702900257"
 	producer, err := sarama.NewSyncProducer(brokerPeers, nil)
 	require.NoError(t, err)
+
 	_, _, err = producer.SendMessage(&sarama.ProducerMessage{Topic: k.Topic, Value: sarama.StringEncoder(msg)})
+	require.NoError(t, err)
+
 	producer.Close()
 
 	var acc testutil.Accumulator


### PR DESCRIPTION
This PR adds one additional _no-error_ check to integration test (which helps a lot when something wrong with Kafka).

And alse I've updated readme a little bit (some instructions were outdated).