### PR TITLE
Replace openTSDB docker image with the official one

### DIFF
--- a/outputs/opentsdb/opentsdb_test.go
+++ b/outputs/opentsdb/opentsdb_test.go
@@ -46,7 +46,7 @@ func TestWrite(t *testing.T) {
 
 	o := &OpenTSDB{
 		Host:   testutil.GetLocalHost(),
-		Port:   24242,
+		Port:   4242,
 		Prefix: "prefix.test.",
 	}
 

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -34,9 +34,9 @@ rabbitmq:
         - "5672:5672"
 
 opentsdb:
-    image: lancope/opentsdb
+    image: petergrace/opentsdb-docker
     ports:
-        - "24242:4242"
+        - "4242:4242"
 
 redis:
     image: redis


### PR DESCRIPTION
Running integration tests on previously used image (lancope/opentsdb) fails with `No error is expected but got OpenTSDB: Telnet connect fail`.

There is no such problem with [official](http://opentsdb.net/docs/build/html/resources.html) OpenTDSB docker.