### PR TITLE
Use specific mysql version with docker

### DIFF
--- a/plugins/mysql/mysql_test.go
+++ b/plugins/mysql/mysql_test.go
@@ -28,7 +28,7 @@ func TestMysqlGeneratesMetrics(t *testing.T) {
 		prefix string
 		count  int
 	}{
-		{"commands", 141},
+		{"commands", 147},
 		{"handler", 18},
 		{"bytes", 2},
 		{"innodb", 51},

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,5 +1,5 @@
 mysql:
-    image: mysql
+    image: mysql:5.7
     ports:
         - "3306:3306"
     environment:


### PR DESCRIPTION
Yet another problem with Docker setup.
MySQL has different status fields in different version, so we should specify version in docker-compose.yml. 

P.S. Maybe it's better to refactor these test somehow to make them independent on mysql version.