### PR TITLE
Parse statsd lines with multiple metric bits

### DIFF
--- a/plugins/statsd/README.md
+++ b/plugins/statsd/README.md
@@ -26,6 +26,26 @@ implementation. In short, the telegraf statsd listener will accept:
     - `load.time.nanoseconds:1|h`
     - `load.time:200|ms|@0.1` <- sampled 1/10 of the time
 
+It is possible to omit repetitive names and merge individual stats into a
+single line by separating them with additional colons:
+
+  - `users.current.den001.myapp:32|g:+10|g:-10|g`
+  - `deploys.test.myservice:1|c:101|c:1|c|@0.1`
+  - `users.unique:101|s:101|s:102|s`
+  - `load.time:320|ms:200|ms|@0.1`
+
+This also allows for mixed types in a single line:
+
+  - `foo:1|c:200|ms`
+
+The internals for this do parse out the metric name and repeativly use it to
+create new packets for each bit in the line that can be separated by colon.
+The parser will copy down the metric name to each bit until a newline is found.
+
+The string `foo:1|c:200|ms` is internally split into two individual metrics
+`foo:1|c` and `foo:200|ms` which are added to the aggregator separately.
+
+
 #### Influx Statsd
 
 In order to take advantage of InfluxDB's tagging system, we have made a couple


### PR DESCRIPTION
This resembles the parsing which is done in etsy/statsd to add multiple datapoints for a measurement in a single line.
https://github.com/etsy/statsd/blob/243a1f2a166c2d573f7582dc0c42f50f257e4150/stats.js#L225-L277

It seems as if some client applications use those possibilities to pack more data into each UDP packet and simply omit the repeating measurement name where possible.

An example for this is the Kamon.io statsd reporter which produces lines like these:
```
kamon.host.akka-actor.kamon_user_kamon-system-metrics_sigar-metrics-recorder.processing-time:581632|ms:593920|ms:610304|ms:622592|ms:634880|ms:638976|ms:659456|ms:679936|ms:720896|ms:770048|ms
kamon.host.akka-actor.kamon_user_kamon-system-metrics_sigar-metrics-recorder.time-in-mailbox:5664|ms:6176|ms:6240|ms|@0.5:6304|ms:6336|ms:6656|ms:6720|ms:7072|ms:12288|ms
```
