### PR TITLE
redis: support IPv6 addresses with no port

### DIFF
--- a/plugins/redis/redis.go
+++ b/plugins/redis/redis.go
@@ -114,7 +114,7 @@ const defaultPort = "6379"
 func (r *Redis) gatherServer(addr *url.URL, acc plugins.Accumulator) error {
 	_, _, err := net.SplitHostPort(addr.Host)
 	if err != nil {
-		addr.Host = addr.Host + ":" + defaultPort
+		addr.Host = net.JoinHostPort(addr.Host, defaultPort)
 	}
 
 	c, err := net.Dial("tcp", addr.Host)


### PR DESCRIPTION
Here's a fix for a contrived bug I found. Without this change, telegraf generates the address ::1:6379, which is invalid, when you use `servers = ["tcp://::1"]` or any other IPv6 address with no port in the redis plugin config.

Sample config:

```
[tags]
[agent]
  interval = "10s"
  round_interval = true
  flush_interval = "10s"
  flush_jitter = "0s"
  debug = false
  hostname = ""

[outputs]
[outputs.influxdb]
  urls = ["http://localhost:8086"] # required
  database = "telegraf" # required
  precision = "s"

[redis]
  servers = ["tcp://::1"]
```

Result without this change:

```
2015/11/09 21:53:19 Starting Telegraf (version v0.2.0-39-g1accab0)
2015/11/09 21:53:19 Loaded outputs: influxdb
2015/11/09 21:53:19 Loaded plugins: redis
2015/11/09 21:53:19 Tags enabled:
2015/11/09 21:53:19 Agent Config: Interval:10s, Debug:false, Hostname:"blah", Flush Interval:10s
2015/11/09 21:53:20 Error in plugin [redis]: Unable to connect to redis server '::1:6379': dial tcp: too many colons in address ::1:6379
2015/11/09 21:53:20 Gathered metrics, (10s interval), from 1 plugins in 221.722µs
2015/11/09 21:53:24 Hang on, flushing any cached points before shutdown
```

Results with this change (note, I wasn't actually running redis):

```
2015/11/09 22:00:11 Starting Telegraf (version v0.2.0-40-g71ff506)
2015/11/09 22:00:11 Loaded outputs: influxdb
2015/11/09 22:00:11 Loaded plugins: redis
2015/11/09 22:00:11 Tags enabled:
2015/11/09 22:00:11 Agent Config: Interval:10s, Debug:false, Hostname:"blah", Flush Interval:10s
2015/11/09 22:00:20 Error in plugin [redis]: Unable to connect to redis server '[::1]:6379': dial tcp [::1]:6379: getsockopt: connection refused
2015/11/09 22:00:20 Gathered metrics, (10s interval), from 1 plugins in 552.257µs
2015/11/09 22:00:23 Hang on, flushing any cached points before shutdown
```