### PR TITLE
measurement name should have prefix before ShouldPass check

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -92,6 +92,10 @@ func (ac *accumulator) AddFields(
 		timestamp = time.Now()
 	}
 
+	if ac.prefix != "" {
+		measurement = ac.prefix + measurement
+	}
+
 	if ac.plugin != nil {
 		if !ac.plugin.ShouldPass(measurement, tags) {
 			return
@@ -102,10 +106,6 @@ func (ac *accumulator) AddFields(
 		if _, ok := tags[k]; !ok {
 			tags[k] = v
 		}
-	}
-
-	if ac.prefix != "" {
-		measurement = ac.prefix + measurement
 	}
 
 	pt, err := client.NewPoint(measurement, tags, fields, timestamp)

--- a/plugins/phpfpm/README.md
+++ b/plugins/phpfpm/README.md
@@ -30,13 +30,14 @@ Using this configuration:
   # An array of address to gather stats about. Specify an ip on hostname
   # with optional port and path. ie localhost, 10.10.3.33/server-status, etc.
   #
-  # We can configure int two modes:
+  # We can configure in three modes:
   #   - unixsocket: the string is the path to fpm socket like
   #      /var/run/php5-fpm.sock
   #   - http: the URL has to start with http:// or https://
+  #   - fcgi: the URL has to start with fcgi:// or cgi://, and socket port must present
   #
   # If no servers are specified, then default to 127.0.0.1/server-status
-  urls = ["http://localhost/status", "10.0.0.12:/var/run/php5-fpm-www2.sock"]
+  urls = ["http://localhost/status", "10.0.0.12:/var/run/php5-fpm-www2.sock", "fcgi://10.0.0.12:9000/status"]
 ```
 
 When run with:
@@ -70,4 +71,15 @@ It produces:
 > [url="localhost" pool="www2"] phpfpm_max_active_processes value=2
 > [url="localhost" pool="www2"] phpfpm_accepted_conn value=306
 > [url="localhost" pool="www2"] phpfpm_listen_queue value=0
+
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_max_children_reached value=0
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_slow_requests value=1
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_max_listen_queue value=0
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_active_processes value=1
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_listen_queue_len value=0
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_idle_processes value=2
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_total_processes value=2
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_max_active_processes value=2
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_accepted_conn value=307
+> [url="10.0.0.12:9000" pool="www3"] phpfpm_listen_queue value=0
 ```

--- a/plugins/phpfpm/phpfpm.go
+++ b/plugins/phpfpm/phpfpm.go
@@ -118,25 +118,25 @@ func (g *phpfpm) gatherServer(addr string, acc plugins.Accumulator) error {
 
 		importMetric(res.Body, acc, u.Host)
 	} else {
-        var (
-            fcgi *FCGIClient
-            fcgiAddr string
-        )
-        if strings.HasPrefix(addr, "fcgi://") || strings.HasPrefix(addr, "cgi://") {
-            u, err := url.Parge(addr)
-		    if err != nil {
-			    return fmt.Errorf("Unable parse server address '%s': %s", addr, err)
-		    }
-            socketAddr := strings.Split(u.Host,":")
-            fcgiIp := socketAddr[0]
-            fcgiPort := strconv.Atoi(socketAddr[1])
-            fcgiAddr = u.Host
-            fcgi, _ = NewClient(fcgiIp,fcgiPort)
-        } else {
-		    socketAddr := strings.Split(addr, ":")
-            fcgiAddr = socketAddr[0]
-		    fcgi, _ = NewClient("unix", socketAddr[1])
-        }
+		var (
+			fcgi     *FCGIClient
+			fcgiAddr string
+		)
+		if strings.HasPrefix(addr, "fcgi://") || strings.HasPrefix(addr, "cgi://") {
+			u, err := url.Parge(addr)
+			if err != nil {
+				return fmt.Errorf("Unable parse server address '%s': %s", addr, err)
+			}
+			socketAddr := strings.Split(u.Host, ":")
+			fcgiIp := socketAddr[0]
+			fcgiPort := strconv.Atoi(socketAddr[1])
+			fcgiAddr = u.Host
+			fcgi, _ = NewClient(fcgiIp, fcgiPort)
+		} else {
+			socketAddr := strings.Split(addr, ":")
+			fcgiAddr = socketAddr[0]
+			fcgi, _ = NewClient("unix", socketAddr[1])
+		}
 		resOut, resErr, err := fcgi.Request(map[string]string{
 			"SCRIPT_NAME":     "/status",
 			"SCRIPT_FILENAME": "status",

--- a/plugins/phpfpm/phpfpm.go
+++ b/plugins/phpfpm/phpfpm.go
@@ -42,13 +42,16 @@ var sampleConfig = `
   # An array of addresses to gather stats about. Specify an ip or hostname
   # with optional port and path.
   #
-  # Plugin can be configured in two modes (both can be used):
+  # Plugin can be configured in three modes (both can be used):
   #   - http: the URL must start with http:// or https://, ex:
   #       "http://localhost/status"
   #       "http://192.168.130.1/status?full"
   #   - unixsocket: path to fpm socket, ex:
   #       "/var/run/php5-fpm.sock"
   #       "192.168.10.10:/var/run/php5-fpm-www2.sock"
+  #   - fcgi: the URL mush start with fcgi:// or cgi://, and port must present, ex:
+  #       "fcgi://10.0.0.12:9000/status"
+  #       "cgi://10.0.10.12:9001/status"
   #
   # If no servers are specified, then default to 127.0.0.1/server-status
   urls = ["http://localhost/status"]
@@ -115,9 +118,25 @@ func (g *phpfpm) gatherServer(addr string, acc plugins.Accumulator) error {
 
 		importMetric(res.Body, acc, u.Host)
 	} else {
-		socketAddr := strings.Split(addr, ":")
-
-		fcgi, _ := NewClient("unix", socketAddr[1])
+        var (
+            fcgi *FCGIClient
+            fcgiAddr string
+        )
+        if strings.HasPrefix(addr, "fcgi://") || strings.HasPrefix(addr, "cgi://") {
+            u, err := url.Parge(addr)
+		    if err != nil {
+			    return fmt.Errorf("Unable parse server address '%s': %s", addr, err)
+		    }
+            socketAddr := strings.Split(u.Host,":")
+            fcgiIp := socketAddr[0]
+            fcgiPort := strconv.Atoi(socketAddr[1])
+            fcgiAddr = u.Host
+            fcgi, _ = NewClient(fcgiIp,fcgiPort)
+        } else {
+		    socketAddr := strings.Split(addr, ":")
+            fcgiAddr = socketAddr[0]
+		    fcgi, _ = NewClient("unix", socketAddr[1])
+        }
 		resOut, resErr, err := fcgi.Request(map[string]string{
 			"SCRIPT_NAME":     "/status",
 			"SCRIPT_FILENAME": "status",
@@ -125,7 +144,7 @@ func (g *phpfpm) gatherServer(addr string, acc plugins.Accumulator) error {
 		}, "")
 
 		if len(resErr) == 0 && err == nil {
-			importMetric(bytes.NewReader(resOut), acc, socketAddr[0])
+			importMetric(bytes.NewReader(resOut), acc, fcgiAddr)
 		}
 
 	}

--- a/plugins/phpfpm/phpfpm.go
+++ b/plugins/phpfpm/phpfpm.go
@@ -129,7 +129,7 @@ func (g *phpfpm) gatherServer(addr string, acc plugins.Accumulator) error {
 			}
 			socketAddr := strings.Split(u.Host, ":")
 			fcgiIp := socketAddr[0]
-			fcgiPort := strconv.Atoi(socketAddr[1])
+			fcgiPort,_ := strconv.Atoi(socketAddr[1])
 			fcgiAddr = u.Host
 			fcgi, _ = NewClient(fcgiIp, fcgiPort)
 		} else {

--- a/plugins/phpfpm/phpfpm.go
+++ b/plugins/phpfpm/phpfpm.go
@@ -129,7 +129,7 @@ func (g *phpfpm) gatherServer(addr string, acc plugins.Accumulator) error {
 			}
 			socketAddr := strings.Split(u.Host, ":")
 			fcgiIp := socketAddr[0]
-			fcgiPort,_ := strconv.Atoi(socketAddr[1])
+			fcgiPort, _ := strconv.Atoi(socketAddr[1])
 			fcgiAddr = u.Host
 			fcgi, _ = NewClient(fcgiIp, fcgiPort)
 		} else {

--- a/plugins/phpfpm/phpfpm.go
+++ b/plugins/phpfpm/phpfpm.go
@@ -123,7 +123,7 @@ func (g *phpfpm) gatherServer(addr string, acc plugins.Accumulator) error {
 			fcgiAddr string
 		)
 		if strings.HasPrefix(addr, "fcgi://") || strings.HasPrefix(addr, "cgi://") {
-			u, err := url.Parge(addr)
+			u, err := url.Parse(addr)
 			if err != nil {
 				return fmt.Errorf("Unable parse server address '%s': %s", addr, err)
 			}


### PR DESCRIPTION
fix for sample config 
[cpu]
drop=["cpu_time"]
would fail.