### PR TITLE
Add protocol stats to the network plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#415](https://github.com/influxdb/telegraf/issues/415): memcached plugin: support unix sockets
 - [#418](https://github.com/influxdb/telegraf/pull/418): memcached plugin additional unit tests.
 - [#408](https://github.com/influxdb/telegraf/pull/408): MailChimp plugin.
+- [#382](https://github.com/influxdb/telegraf/pull/382): Add system wide network protocol stats to `net` plugin.
 
 ### Bugfixes
 - [#405](https://github.com/influxdb/telegraf/issues/405): Prometheus output cardinality issue
@@ -83,7 +84,6 @@ same type.
 - [#364](https://github.com/influxdb/telegraf/pull/364): Support InfluxDB UDP output.
 - [#370](https://github.com/influxdb/telegraf/pull/370): Support specifying multiple outputs, as lists.
 - [#372](https://github.com/influxdb/telegraf/pull/372): Remove gosigar and update go-dockerclient for FreeBSD support. Thanks @MerlinDMC!
-- [#382](https://github.com/influxdb/telegraf/pull/382): Add system wide network protocol stats to `net` plugin.
 
 ### Bugfixes
 - [#331](https://github.com/influxdb/telegraf/pull/331): Dont overwrite host tag in redis plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ same type.
 - [#364](https://github.com/influxdb/telegraf/pull/364): Support InfluxDB UDP output.
 - [#370](https://github.com/influxdb/telegraf/pull/370): Support specifying multiple outputs, as lists.
 - [#372](https://github.com/influxdb/telegraf/pull/372): Remove gosigar and update go-dockerclient for FreeBSD support. Thanks @MerlinDMC!
+- [#382](https://github.com/influxdb/telegraf/pull/382): Add system wide network protocol stats to `net` plugin.
 
 ### Bugfixes
 - [#331](https://github.com/influxdb/telegraf/pull/331): Dont overwrite host tag in redis plugin.

--- a/plugins/system/mock_PS.go
+++ b/plugins/system/mock_PS.go
@@ -1,13 +1,15 @@
 package system
 
-import "github.com/stretchr/testify/mock"
+import (
+	"github.com/stretchr/testify/mock"
 
-import "github.com/shirou/gopsutil/cpu"
-import "github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/disk"
 
-import "github.com/shirou/gopsutil/load"
-import "github.com/shirou/gopsutil/mem"
-import "github.com/shirou/gopsutil/net"
+	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/net"
+)
 
 type MockPS struct {
 	mock.Mock
@@ -21,6 +23,7 @@ func (m *MockPS) LoadAvg() (*load.LoadAvgStat, error) {
 
 	return r0, r1
 }
+
 func (m *MockPS) CPUTimes(perCPU, totalCPU bool) ([]cpu.CPUTimesStat, error) {
 	ret := m.Called()
 
@@ -29,6 +32,7 @@ func (m *MockPS) CPUTimes(perCPU, totalCPU bool) ([]cpu.CPUTimesStat, error) {
 
 	return r0, r1
 }
+
 func (m *MockPS) DiskUsage() ([]*disk.DiskUsageStat, error) {
 	ret := m.Called()
 
@@ -37,6 +41,7 @@ func (m *MockPS) DiskUsage() ([]*disk.DiskUsageStat, error) {
 
 	return r0, r1
 }
+
 func (m *MockPS) NetIO() ([]net.NetIOCountersStat, error) {
 	ret := m.Called()
 
@@ -45,6 +50,16 @@ func (m *MockPS) NetIO() ([]net.NetIOCountersStat, error) {
 
 	return r0, r1
 }
+
+func (m *MockPS) NetProto() ([]net.NetProtoCountersStat, error) {
+	ret := m.Called()
+
+	r0 := ret.Get(0).([]net.NetProtoCountersStat)
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+
 func (m *MockPS) DiskIO() (map[string]disk.DiskIOCountersStat, error) {
 	ret := m.Called()
 
@@ -53,6 +68,7 @@ func (m *MockPS) DiskIO() (map[string]disk.DiskIOCountersStat, error) {
 
 	return r0, r1
 }
+
 func (m *MockPS) VMStat() (*mem.VirtualMemoryStat, error) {
 	ret := m.Called()
 
@@ -61,6 +77,7 @@ func (m *MockPS) VMStat() (*mem.VirtualMemoryStat, error) {
 
 	return r0, r1
 }
+
 func (m *MockPS) SwapStat() (*mem.SwapMemoryStat, error) {
 	ret := m.Called()
 
@@ -69,6 +86,7 @@ func (m *MockPS) SwapStat() (*mem.SwapMemoryStat, error) {
 
 	return r0, r1
 }
+
 func (m *MockPS) DockerStat() ([]*DockerContainerStat, error) {
 	ret := m.Called()
 
@@ -77,6 +95,7 @@ func (m *MockPS) DockerStat() ([]*DockerContainerStat, error) {
 
 	return r0, r1
 }
+
 func (m *MockPS) NetConnections() ([]net.NetConnectionStat, error) {
 	ret := m.Called()
 

--- a/plugins/system/net.go
+++ b/plugins/system/net.go
@@ -81,10 +81,12 @@ func (s *NetIOStats) Gather(acc plugins.Accumulator) error {
 	}
 
 	// Get system wide stats for different network protocols
-	netprotos, err := s.ps.NetProto()
+	// (ignore these stats if the call fails)
+	netprotos, _ := s.ps.NetProto()
 	for _, proto := range netprotos {
 		for stat, value := range proto.Stats {
-			name := fmt.Sprintf("%s_%s", proto.Protocol, strings.ToLower(stat))
+			name := fmt.Sprintf("%s_%s", strings.ToLower(proto.Protocol),
+				strings.ToLower(stat))
 			acc.Add(name, value, nil)
 		}
 	}

--- a/plugins/system/net.go
+++ b/plugins/system/net.go
@@ -3,6 +3,7 @@ package system
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/influxdb/telegraf/plugins"
 )
@@ -77,6 +78,15 @@ func (s *NetIOStats) Gather(acc plugins.Accumulator) error {
 		acc.Add("err_out", io.Errout, tags)
 		acc.Add("drop_in", io.Dropin, tags)
 		acc.Add("drop_out", io.Dropout, tags)
+	}
+
+	// Get system wide stats for different network protocols
+	netprotos, err := s.ps.NetProto()
+	for _, proto := range netprotos {
+		for stat, value := range proto.Stats {
+			name := fmt.Sprintf("%s_%s", proto.Protocol, strings.ToLower(stat))
+			acc.Add(name, value, nil)
+		}
 	}
 
 	return nil

--- a/plugins/system/ps.go
+++ b/plugins/system/ps.go
@@ -29,6 +29,7 @@ type PS interface {
 	CPUTimes(perCPU, totalCPU bool) ([]cpu.CPUTimesStat, error)
 	DiskUsage() ([]*disk.DiskUsageStat, error)
 	NetIO() ([]net.NetIOCountersStat, error)
+	NetProto() ([]net.NetProtoCountersStat, error)
 	DiskIO() (map[string]disk.DiskIOCountersStat, error)
 	VMStat() (*mem.VirtualMemoryStat, error)
 	SwapStat() (*mem.SwapMemoryStat, error)
@@ -86,6 +87,10 @@ func (s *systemPS) DiskUsage() ([]*disk.DiskUsageStat, error) {
 	}
 
 	return usage, nil
+}
+
+func (s *systemPS) NetProto() ([]net.NetProtoCountersStat, error) {
+	return net.NetProtoCounters(nil)
 }
 
 func (s *systemPS) NetIO() ([]net.NetIOCountersStat, error) {

--- a/plugins/system/system_test.go
+++ b/plugins/system/system_test.go
@@ -113,6 +113,17 @@ func TestSystemStats_GenerateStats(t *testing.T) {
 
 	mps.On("NetIO").Return([]net.NetIOCountersStat{netio}, nil)
 
+	netprotos := []net.NetProtoCountersStat{
+		net.NetProtoCountersStat{
+			Protocol: "Udp",
+			Stats: map[string]int64{
+				"InDatagrams": 4655,
+				"NoPorts":     892592,
+			},
+		},
+	}
+	mps.On("NetProto").Return(netprotos, nil)
+
 	vms := &mem.VirtualMemoryStat{
 		Total:     12400,
 		Available: 7600,
@@ -273,6 +284,8 @@ func TestSystemStats_GenerateStats(t *testing.T) {
 	assert.NoError(t, acc.ValidateTaggedValue("err_out", uint64(8), ntags))
 	assert.NoError(t, acc.ValidateTaggedValue("drop_in", uint64(7), ntags))
 	assert.NoError(t, acc.ValidateTaggedValue("drop_out", uint64(1), ntags))
+	assert.NoError(t, acc.ValidateValue("udp_noports", int64(892592)))
+	assert.NoError(t, acc.ValidateValue("udp_indatagrams", int64(4655)))
 
 	preDiskIOPoints := len(acc.Points)
 


### PR DESCRIPTION
This add the system wide network protocol stats to the `net` plugin.

Uses a new method in `gopsutil` see https://github.com/shirou/gopsutil/pull/109

Basically exposes all the data in `/proc/net/snmp` as

`net_PROTOCOL_COLNAME`

for example:

Excerpt from /proc/net/snmp
```
Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti
Udp: 67688650 3723361 58108572 124599763 58108572 0 0 318767
```

adds measurement `net_udp_rcvbuferrors` with value 58108572 etc.

