### PR TITLE
Skip measurements with NaN fields

### DIFF
--- a/plugins/prometheus/prometheus.go
+++ b/plugins/prometheus/prometheus.go
@@ -87,7 +87,8 @@ func (g *Prometheus) gatherURL(url string, acc plugins.Accumulator) error {
 				}
 				tags[string(key)] = string(value)
 			}
-			acc.Add(string(sample.Metric[model.MetricNameLabel]), float64(sample.Value), tags)
+			acc.Add(string(sample.Metric[model.MetricNameLabel]),
+				float64(sample.Value), tags)
 		}
 	}
 


### PR DESCRIPTION
fixes #389 

@rvignaud this will fix the error messages and panic that you were seeing, it will simply skip measurements that have NaN fields.