### PR TITLE
Use pgrep with a pattern

### DIFF
--- a/plugins/procstat/procstat.go
+++ b/plugins/procstat/procstat.go
@@ -36,6 +36,7 @@ var sampleConfig = `
   pid_file = "/var/run/nginx.pid"
   # executable name (used by pgrep)
   # exe = "nginx"
+  # pattern as argument for pgrep -f
   # pattern = "nginx"
 `
 


### PR DESCRIPTION
Added a new option to find process by a pattern using `pgrep -f`.