### PR TITLE
cmd/telegraf: -configdirectory only includes files ending in .conf

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -18,7 +18,7 @@ var fDebug = flag.Bool("debug", false,
 var fTest = flag.Bool("test", false, "gather metrics, print them out, and exit")
 var fConfig = flag.String("config", "", "configuration file to load")
 var fConfigDirectory = flag.String("configdirectory", "",
-	"directory containing additional configuration files")
+	"directory containing additional *.conf files")
 var fVersion = flag.Bool("version", false, "display the version")
 var fSampleConfig = flag.Bool("sample-config", false,
 	"print out full sample configuration")


### PR DESCRIPTION
This requirement doesn't seem to be documented anywhere except by digging through the code:

		if name[len(name)-5:] != ".conf" {
			continue
		}

https://github.com/influxdb/telegraf/blob/889c0a50a4aeaf4b343fbd7d2b8d9236cfc25a5b/config.go#L415