### PR TITLE
Change aerospike plugin server tag to aerospike_host

### DIFF
--- a/plugins/aerospike/aerospike.go
+++ b/plugins/aerospike/aerospike.go
@@ -250,8 +250,8 @@ func get(key []byte, host string) (map[string]string, error) {
 func readAerospikeStats(stats map[string]string, acc plugins.Accumulator, host, namespace string) {
 	for key, value := range stats {
 		tags := map[string]string{
-			"host":      host,
-			"namespace": "_service",
+			"aerospike_host": host,
+			"namespace":      "_service",
 		}
 
 		if namespace != "" {

--- a/plugins/aerospike/aerospike_test.go
+++ b/plugins/aerospike/aerospike_test.go
@@ -67,8 +67,8 @@ func TestReadAerospikeStatsNamespace(t *testing.T) {
 	readAerospikeStats(stats, &acc, "host1", "test")
 
 	tags := map[string]string{
-		"host":      "host1",
-		"namespace": "test",
+		"aerospike_host": "host1",
+		"namespace":      "test",
 	}
 	for k := range stats {
 		assert.True(t, acc.ValidateTaggedValue(k, int64(12345), tags) == nil)


### PR DESCRIPTION
This is to avoid a conflict with the standard "host" tag that is
used everywhere.