### PR TITLE
Add support for pass/drop/tagpass/tagdrop for outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ Below is how to configure `tagpass` and `tagdrop` parameters (added in 0.1.5)
     path = [ "/opt", "/home" ]
 ```
 
+Below is how to configure `pass` and `drop` parameters (added in 0.1.5)
+
+```
+# Drop all metrics for guest CPU usage
+[[plugins.cpu]]
+  drop = [ "cpu_usage_guest" ]
+
+# Only store inode related metrics for disks
+[[plugins.disk]]
+  pass = [ "disk_inodes" ]
+```
+
+
 Additional plugins (or outputs) of the same type can be specified,
 just define another instance in the config file:
 
@@ -223,6 +236,27 @@ want to add support for another service or third-party API.
 Telegraf also supports specifying multiple output sinks to send data to,
 configuring each output sink is different, but examples can be
 found by running `telegraf -sample-config`.
+
+Outputs also support the same configurable options as plugins (pass, drop, tagpass, tagdrop)
+
+```
+[[outputs.influxdb]]
+  urls = [ "http://localhost:8086" ]
+  database = "telegraf"
+  # Drop all measurements that start with "aerospike"
+  drop = ["aerospike"]
+
+# Send to a different database
+[[outputs.influxdb]]
+  urls = [ "http://localhost:8086" ]
+  database = "mydb"
+  precision = "s"
+
+# Only store measurements where the tag "mytag" matches the value "B"
+[outputs.influxdb.tagpass]
+  mytag = ["B"]
+```
+
 
 ## Supported Outputs
 

--- a/accumulator.go
+++ b/accumulator.go
@@ -107,7 +107,7 @@ func (ac *accumulator) AddFields(
 	}
 
 	if ac.pluginConfig != nil {
-		if !ac.pluginConfig.ShouldPass(measurement) || !ac.pluginConfig.ShouldTagsPass(tags) {
+		if !ac.pluginConfig.Filter.ShouldPass(measurement) || !ac.pluginConfig.Filter.ShouldTagsPass(tags) {
 			return
 		}
 	}

--- a/agent.go
+++ b/agent.go
@@ -226,12 +226,13 @@ func (a *Agent) writeOutput(
 	start := time.Now()
 
 	for {
-		err := ro.Output.Write(points)
+		filtered := ro.FilterPoints(points)
+		err := ro.Output.Write(filtered)
 		if err == nil {
 			// Write successful
 			elapsed := time.Since(start)
 			log.Printf("Flushed %d metrics to output %s in %s\n",
-				len(points), ro.Name, elapsed)
+				len(filtered), ro.Name, elapsed)
 			return
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,19 +20,22 @@ func TestConfig_LoadSinglePlugin(t *testing.T) {
 
 	mConfig := &PluginConfig{
 		Name: "memcached",
-		Drop: []string{"other", "stuff"},
-		Pass: []string{"some", "strings"},
-		TagDrop: []TagFilter{
-			TagFilter{
-				Name:   "badtag",
-				Filter: []string{"othertag"},
+		Filter: Filter{
+			Drop: []string{"other", "stuff"},
+			Pass: []string{"some", "strings"},
+			TagDrop: []TagFilter{
+				TagFilter{
+					Name:   "badtag",
+					Filter: []string{"othertag"},
+				},
 			},
-		},
-		TagPass: []TagFilter{
-			TagFilter{
-				Name:   "goodtag",
-				Filter: []string{"mytag"},
+			TagPass: []TagFilter{
+				TagFilter{
+					Name:   "goodtag",
+					Filter: []string{"mytag"},
+				},
 			},
+			IsActive: true,
 		},
 		Interval: 5 * time.Second,
 	}
@@ -59,19 +62,22 @@ func TestConfig_LoadDirectory(t *testing.T) {
 
 	mConfig := &PluginConfig{
 		Name: "memcached",
-		Drop: []string{"other", "stuff"},
-		Pass: []string{"some", "strings"},
-		TagDrop: []TagFilter{
-			TagFilter{
-				Name:   "badtag",
-				Filter: []string{"othertag"},
+		Filter: Filter{
+			Drop: []string{"other", "stuff"},
+			Pass: []string{"some", "strings"},
+			TagDrop: []TagFilter{
+				TagFilter{
+					Name:   "badtag",
+					Filter: []string{"othertag"},
+				},
 			},
-		},
-		TagPass: []TagFilter{
-			TagFilter{
-				Name:   "goodtag",
-				Filter: []string{"mytag"},
+			TagPass: []TagFilter{
+				TagFilter{
+					Name:   "goodtag",
+					Filter: []string{"mytag"},
+				},
 			},
+			IsActive: true,
 		},
 		Interval: 5 * time.Second,
 	}


### PR DESCRIPTION
Reuses a lot of the logic for the plugin configuration, and changed
the ConfiguredPlugin struct to be ConfiguredFilter and a generic
function to parse the filter (called parseFilter).

X-Github-Closes #398