### PR TITLE
Adding remaining memcached stats

### DIFF
--- a/plugins/memcached/memcached.go
+++ b/plugins/memcached/memcached.go
@@ -33,6 +33,28 @@ var sendAsIs = []string{
 	"evictions",
 	"limit_maxbytes",
 	"bytes",
+	"uptime",
+	"curr_items",
+	"total_items",
+	"curr_connections",
+	"total_connections",
+	"connection_structures",
+	"cmd_get",
+	"cmd_set",
+	"delete_hits",
+	"delete_misses",
+	"incr_hits",
+	"incr_misses",
+	"decr_hits",
+	"decr_misses",
+	"cas_hits",
+	"cas_misses",
+	"cas_badvalue",
+	"evictions",
+	"bytes_read",
+	"bytes_written",
+	"threads",
+	"conn_yields"
 }
 
 // SampleConfig returns sample configuration message

--- a/plugins/memcached/memcached.go
+++ b/plugins/memcached/memcached.go
@@ -49,7 +49,6 @@ var sendAsIs = []string{
 	"decr_misses",
 	"cas_hits",
 	"cas_misses",
-	"cas_badvalue",
 	"evictions",
 	"bytes_read",
 	"bytes_written",

--- a/plugins/memcached/memcached.go
+++ b/plugins/memcached/memcached.go
@@ -54,7 +54,7 @@ var sendAsIs = []string{
 	"bytes_read",
 	"bytes_written",
 	"threads",
-	"conn_yields"
+	"conn_yields",
 }
 
 // SampleConfig returns sample configuration message

--- a/plugins/memcached/memcached_test.go
+++ b/plugins/memcached/memcached_test.go
@@ -22,7 +22,7 @@ func TestMemcachedGeneratesMetrics(t *testing.T) {
 	err := m.Gather(&acc)
 	require.NoError(t, err)
 
-	intMetrics := []string{"get_hits", "get_misses", "evictions", "limit_maxbytes", "bytes", "uptime", "curr_items", "total_items", "curr_connections", "total_connections", "connection_structures", "cmd_get", "cmd_set", "delete_hits", "delete_misses", "incr_hits", "incr_misses", "decr_hits", "decr_misses", "cas_hits", "cas_misses", "cas_badvalue", "evictions", "bytes_read", "bytes_written", "threads", "conn_yields"}
+	intMetrics := []string{"get_hits", "get_misses", "evictions", "limit_maxbytes", "bytes", "uptime", "curr_items", "total_items", "curr_connections", "total_connections", "connection_structures", "cmd_get", "cmd_set", "delete_hits", "delete_misses", "incr_hits", "incr_misses", "decr_hits", "decr_misses", "cas_hits", "cas_misses", "evictions", "bytes_read", "bytes_written", "threads", "conn_yields"}
 
 	for _, metric := range intMetrics {
 		assert.True(t, acc.HasIntValue(metric), metric)

--- a/plugins/memcached/memcached_test.go
+++ b/plugins/memcached/memcached_test.go
@@ -22,7 +22,7 @@ func TestMemcachedGeneratesMetrics(t *testing.T) {
 	err := m.Gather(&acc)
 	require.NoError(t, err)
 
-	intMetrics := []string{"get_hits", "get_misses", "evictions", "limit_maxbytes", "bytes"}
+	intMetrics := []string{"get_hits", "get_misses", "evictions", "limit_maxbytes", "bytes", "uptime", "curr_items", "total_items", "curr_connections", "total_connections", "connection_structures", "cmd_get", "cmd_set", "delete_hits", "delete_misses", "incr_hits", "incr_misses", "decr_hits", "decr_misses", "cas_hits", "cas_misses", "cas_badvalue", "evictions", "bytes_read", "bytes_written", "threads", "conn_yields"}
 
 	for _, metric := range intMetrics {
 		assert.True(t, acc.HasIntValue(metric), metric)


### PR DESCRIPTION
I've added the remaining memcached stats as described at https://docs.oracle.com/cd/E17952_01/refman-5.0-en/ha-memcached-stats-general.html to this plugin.